### PR TITLE
Specify mimeType explicitly

### DIFF
--- a/src/tools/https_server/https_server.go
+++ b/src/tools/https_server/https_server.go
@@ -4,14 +4,39 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
+	"path/filepath"
 )
+
+func customFileServer(fs http.FileSystem) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := r.URL.Path
+		ext := filepath.Ext(path)
+
+		mimeTypes := map[string]string{
+			".js":   "application/javascript; charset=UTF-8",
+			".mjs":  "application/javascript; charset=UTF-8",
+			".css":  "text/css; charset=UTF-8",
+			".html": "text/html; charset=UTF-8",
+			".json": "application/json; charset=UTF-8",
+		}
+
+		if mimeType, ok := mimeTypes[ext]; ok {
+			w.Header().Set("Content-Type", mimeType)
+		}
+
+		http.FileServer(fs).ServeHTTP(w, r)
+	})
+}
 
 func main() {
 	var (
 		root = flag.String("root", "web/", "root path")
 	)
 	flag.Parse()
-	http.Handle("/", http.FileServer(http.Dir(*root)))
+
+	fs := http.Dir(*root)
+	http.Handle("/", customFileServer(fs))
+
 	err := http.ListenAndServeTLS(":10041", "cert.pem", "key.pem", nil)
 	if err != nil {
 		fmt.Printf("ERROR : %s", err)


### PR DESCRIPTION
Adding following 

```
<script src="recipient-classifier.mjs" type="module"></script>
<script src="recipient-parser.mjs" type="module"></script>
```

to `dialog.html` raises an error like below.

```
Failed to load module script: Expected a JavaScript module script but the server responded with a MIME type of "text/plain". Strict MIME type checking is enforced for module scripts per HTML spec.
```

We should specify appropriate MIME type in the server side implementation.