### PR TITLE
Remove needless loading of modules

### DIFF
--- a/src/web/dialog.html
+++ b/src/web/dialog.html
@@ -6,8 +6,6 @@
     <script src="https://unpkg.com/@fluentui/web-components" type="module"></script>
     <script src="https://appsforoffice.microsoft.com/lib/1/hosted/office.js" type="text/javascript"  crossorigin="anonymous"></script>
     <script src="https://code.jquery.com/jquery-3.7.1.min.js" integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo=" crossorigin="anonymous"></script>
-    <script src="recipient-parser.mjs" type="module"></script>
-    <script src="recipient-classifier.mjs" type="module"></script>
     <script src="dialog.js" type="module"></script>
     <link href="dialog.css" rel="stylesheet">
 </head>


### PR DESCRIPTION
They modules are loaded via import, so we don't need to load modules with script tags.