### PR TITLE
Use ItemSend instead of OnMessageSend

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -52,10 +52,13 @@
             </Runtime>
           </Runtimes>
           <DesktopFormFactor>
+            <FunctionFile resid="residUILessFunctionFileUrl" />
+            <ExtensionPoint xsi:type="Events">
+              <Event Type="ItemSend" FunctionExecution="synchronous" FunctionName="onMessageSend" />
+            </ExtensionPoint>
             <ExtensionPoint xsi:type="LaunchEvent">
               <LaunchEvents>
                 <LaunchEvent Type="OnNewMessageCompose" FunctionName="onNewMessageComposeCreated"/>
-                <LaunchEvent Type="OnMessageSend" FunctionName="onMessageSend" SendMode="SoftBlock"/>
               </LaunchEvents>
               <SourceLocation resid="residUILessFunctionFileUrl"/>
             </ExtensionPoint>


### PR DESCRIPTION
`OnMessageSend` warns if a handler takes time longer than 5 sec.

https://learn.microsoft.com/en-us/office/dev/add-ins/outlook/onmessagesend-onappointmentsend-events?tabs=windows#long-running-add-in-operations

On the other hand, `ItemSend` accept long time handlers. So we decided to use `ItemSend`.

Note that `ItemSend` always blocks to send a mail if there are some errors to load the addin.