### PR TITLE
Prompt only when outlook web

### DIFF
--- a/src/web/app.js
+++ b/src/web/app.js
@@ -104,12 +104,15 @@ function getAllData(callback) {
 function onMessageSend(event) {
   console.debug("onMessageSend ", event);
   getAllData(function () {
+    // If the platform is web, to bypass pop-up blockers, we need to ask the users if they want to open a dialog.
+    const needToPromptBeforeOpen = Office.context.mailbox.diagnostics.hostName === "OutlookWebApp";
     Office.context.ui.displayDialogAsync(
       window.location.origin + "/dialog.html",
       {
         asyncContext: event,
         height: 60,
         width: 60,
+        promptBeforeOpen: needToPromptBeforeOpen,
       },
       function (asyncResult) {
         const dialog = asyncResult.value;


### PR DESCRIPTION
Specify promptBeforeOpen = true when the platform is outlook on the web.

If the platform is web, to bypass pop-up blockers, we need to ask the users if they want to open a dialog.


## Test

* [x] Confirm that the prompt to ask whether we open a pop-up window is displayed on Outlook on the web.
* [x] Confirm that the prompt to ask whether we open a pop-up window is **not** displayed on the new Outlook for Windows.