### PR TITLE
Update project name and link in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "office-addin-taskpane-js",
+  "name": "office-addin-flex-confirm-mail",
   "version": "0.0.1",
   "repository": {
     "type": "git",
-    "url": "https://github.com/OfficeDev/Office-Addin-TaskPane-JS.git"
+    "url": "https://github.com/FlexConfirmMail/Outlook-Office-Addin"
   },
   "license": "MIT",
   "config": {


### PR DESCRIPTION
The name and link remained the same as in the sample project (office-addin-taskpane-js).
