### PR TITLE
package.json: add watch:run-test-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,21 @@
 * 自己署名証明書のインポート
 * パーソナルHTTPS Webサーバーのビルド
 * `dist`を`tests\run-test-server\web`にコピー
+* テスト用の設定ファイル`tests\run-test-server\configs`を`tests\run-test-server\web`にコピー
 * パーソナルHTTPS Webサーバーで`tests\run-test-server\web`をホスティング
   * https://127.0.0.1:10041でアクセスできるようになる
+
+#### `src`配下の変更を`tests\run-test-server\web`に自動で反映する
+
+`run-test-server.bat`を実行中に、`src`配下への変更を`tests\run-test-server\web`に自動で反映したい場合、
+別のコマンドプロンプトを開き、本リポジトリのルートで以下のnpmコマンドを実行する。
+
+```
+npm run watch:run-test-server
+```
+
+上記のコマンドを実行すると、10秒ごとに`src`の変更を監視し、変更があればリビルドして`tests\run-test-server\web`に出力する。
+上記コマンド実行時、証明書のインポートを求められた場合はインポートすること。
 
 ### Outlookでのテストを行う。
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "stop": "office-addin-debugging stop manifest.xml",
     "test": "run-tiny-esm-test-runner tests/unit/test-*.mjs",
     "validate": "office-addin-manifest validate manifest.xml",
-    "watch": "webpack --mode development --watch"
+    "watch": "webpack --mode development --watch",
+    "watch:run-test-server": "webpack --mode production --watch --output-path tests/run-test-server/web"
   },
   "dependencies": {
     "@microsoft/office-js": "^1.1.90",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "test": "run-tiny-esm-test-runner tests/unit/test-*.mjs",
     "validate": "office-addin-manifest validate manifest.xml",
     "watch": "webpack --mode development --watch",
-    "watch:run-test-server": "webpack --mode production --watch --output-path tests/run-test-server/web"
+    "watch:run-test-server": "webpack --mode production --watch --output-path tests/run-test-server/web --watch-options-poll=10000"
   },
   "dependencies": {
     "@microsoft/office-js": "^1.1.90",


### PR DESCRIPTION
Usage: `npm run watch:run-test-server`.

The command watches contents in `src/web` and if they are updated, automatically build them and output artifacts to `tests/run-test-server/web`.
This is useful if you want to automatically reflect the change of `src/web` to the contens of running `run-test-server.bat`.

