### PR TITLE
Add alert for added new domain

### DIFF
--- a/src/web/app.js
+++ b/src/web/app.js
@@ -176,7 +176,6 @@ window.onItemSend = onItemSend;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 async function onNewMessageComposeCreated(event) {
   const [to, cc, bcc, mailId] = await Promise.all([getToAsync(), getCcAsync(), getBccAsync(), getMailIdAsync()]);
-  console.log(to);
   if (mailId && (to.length > 0 || cc.length > 0 || bcc.length > 0)) {
     const originalRecipients = {
       to,

--- a/src/web/app.js
+++ b/src/web/app.js
@@ -175,7 +175,12 @@ window.onItemSend = onItemSend;
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 async function onNewMessageComposeCreated(event) {
-  const [to, cc, bcc, mailId] = await Promise.all([getToAsync(), getCcAsync(), getBccAsync(), getMailIdAsync()]);
+  const [to, cc, bcc, mailId] = await Promise.all([
+    getToAsync(), 
+    getCcAsync(), 
+    getBccAsync(), 
+    getMailIdAsync()
+  ]);
   if (mailId && (to.length > 0 || cc.length > 0 || bcc.length > 0)) {
     const originalRecipients = {
       to,

--- a/src/web/dialog.css
+++ b/src/web/dialog.css
@@ -33,10 +33,54 @@ fluent-card {
   color:red;
 }
 
-#ok-button {
+.button-container {
   margin-top: 20px;
+  text-align: right;
 }
 
 #cancel-button {
+  margin-left: 10px;
+}
+
+/* fluent-dialog {
+  --dialog-background-color: red;
+  background: red !important;
+  padding: 1.5em;
+  color: white !important;
+  font-size: x-large !important;
+  font-weight: bold !important;
+  text-align: center;
+} */
+
+fluent-dialog::part(control) {
+  color: white;
+  background-color: red;
+  padding: 0 1.5em 1.5em 1.5em;
+  text-align: center;
+  --dialog-width: fit-content;
+  --dialog-height: fit-content;
+}
+
+fluent-dialog::part(control) .newly-added-domain-content {
+  background-color: white;
+  background: var(--bg-color) !important;
+}
+
+fluent-dialog .newly-added-domain-content {
+  color: black;
+  padding: 2em;
+  text-align: left;
+}
+
+fluent-dialog .newly-added-domain-content strong {
+  font-size: large;
+  font-weight: bold;
+}
+
+#cancel-new-domain-button {
+  margin-left: 10px;
+}
+
+.new-domain-button-container {
   margin-top: 20px;
 }

--- a/src/web/dialog.html
+++ b/src/web/dialog.html
@@ -28,8 +28,25 @@
             <fluent-divider></fluent-divider>
             <div id="attachment-and-others"></div>
         </fluent-card>
-        <fluent-button id="ok-button" appearance="accent" onclick="onOk()" disabled>OK</fluent-button>
-        <fluent-button id="cancel-button" onclick="onCancel()">Cancel</button>
+        <div class="button-container">
+            <fluent-button id="send-button" onclick="onSend()" disabled>送信</fluent-button>
+            <fluent-button id="cancel-button" onclick="onCancel()">キャンセル</fluent-button>
+        </div>
     </div>
+    <fluent-dialog id="newly-added-domain-address-dialog" hidden trap-focus modal>
+        <h2>CAUTION!</h2>
+        <div class="newly-added-domain-container">
+            <fluent-card id="newly-added-domains-card" class="newly-added-domain-content">
+                返信元のメールの宛先に含まれていなかったドメインの以下の宛先が追加されています。<br/><br/>
+                <div id="newly-added-domain-address-list">
+                </div>
+                <br/>送信してよろしいですか？
+            </fluent-card>
+            <div class="new-domain-button-container">
+                <fluent-button id="send-new-domain-button" onclick="onSendNewDomain()">送信</fluent-button>
+                <fluent-button id="cancel-new-domain-button" onclick="onCancelNewDomain()">キャンセル</fluent-button>
+            </div>
+        </div>
+    </fluent-dialog>
 </body>
 </html>

--- a/src/web/dialog.js
+++ b/src/web/dialog.js
@@ -5,15 +5,15 @@ class AddedDomainsReconfirmation {
   hasNewDomainAddress = false;
   initialized = false;
 
- /**
- * Parse domain and address of resipients.
- * @param {*} recipients
- * @returns Array<{
- *  recipient,
- *  address,
- *  domain,
- * }>
- */
+  /**
+  * Parse domain and address of resipients.
+  * @param {*} recipients
+  * @returns Array<{
+  *  recipient,
+  *  address,
+  *  domain,
+  * }>
+  */
   parse(recipients) {
     if (!recipients) {
       return [];
@@ -65,6 +65,7 @@ class AddedDomainsReconfirmation {
       $("#newly-added-domain-address-dialog").prop("hidden", true);
     };
   }
+
   show() {
    $("#newly-added-domain-address-dialog").prop("hidden", false);
   }


### PR DESCRIPTION
This is the same function as https://github.com/FlexConfirmMail/Outlook-VSTO-Addin/pull/17. https://github.com/FlexConfirmMail/Outlook-VSTO-Addin/pull/19.

## Specification 

If addresses that have new domains are added on reply, reply all, and forward, a warning dialog like below is displayed on sending the mail.

![image](https://github.com/user-attachments/assets/b4efba69-64c1-4def-89ee-fe8cfa4b996a)

This function is not work if there is no original address like "New Mail".
Also this is not work when editing drafts.

### Details

* Save current recipients of a mail to the session storage when the `OnNewMessageCompose` event fired.
  * `OnNewMessageCompose` is fired on composing a new message (includes reply, reply all, and forward) but not on editing.
  * https://learn.microsoft.com/en-us/office/dev/add-ins/outlook/autolaunch
* Add the saved recipients to the data for the confirmation dialog.
* Check if addresses that have new domains are added in the confirmation dialog.
* Display a warning dialog if addresses that have new domains are added on clicking the "送信" button.
* Remove the saved recipients of the mail from the session storage.

## Test

* [x] Confirm that if  a address that has a new domain is added, the warning dialog about newly added domains is displayed.
* [x] Confirm that if  no address that has a new domain is added, the warning dialog about newly added domains is not displayed.
* [x] Confirm that this function is not work for "New Mail".