### PR TITLE
Reduce extra parsing of recipients

### DIFF
--- a/src/web/added-domains-reconfirmation.mjs
+++ b/src/web/added-domains-reconfirmation.mjs
@@ -1,25 +1,7 @@
-import * as RecipientParser from "./recipient-parser.mjs";
-
 export class AddedDomainsReconfirmation {
   needToConfirm = false;
   newDomainAddresses = new Set();
   initialized = false;
-
-  /**
-   * Parse domain and address of resipients.
-   * @param {*} recipients
-   * @returns Array<{
-   *  recipient,
-   *  address,
-   *  domain,
-   * }>
-   */
-  parse(recipients) {
-    if (!recipients) {
-      return [];
-    }
-    return recipients.map((_) => RecipientParser.parse(_.emailAddress));
-  }
 
   init(data) {
     if (this.initialized) {
@@ -32,17 +14,14 @@ export class AddedDomainsReconfirmation {
     if (!data.originalRecipients) {
       return;
     }
-    const originalToDomains = this.parse(data.originalRecipients.to).map((_) => _.domain);
-    const originalCcDomains = this.parse(data.originalRecipients.cc).map((_) => _.domain);
-    const originalBccDomains = this.parse(data.originalRecipients.bcc).map((_) => _.domain);
+    const originalToDomains = data.originalRecipients.to.map((_) => _.domain);
+    const originalCcDomains = data.originalRecipients.cc.map((_) => _.domain);
+    const originalBccDomains = data.originalRecipients.bcc.map((_) => _.domain);
     const originalDomains = new Set([...originalToDomains, ...originalCcDomains, ...originalBccDomains]);
     if (originalDomains.size === 0) {
       return;
     }
-    const targetToRecipients = this.parse(data.target.to);
-    const targetCcRecipients = this.parse(data.target.cc);
-    const targetBccRecipients = this.parse(data.target.bcc);
-    const targetRecipients = new Set([...targetToRecipients, ...targetCcRecipients, ...targetBccRecipients]);
+    const targetRecipients = new Set([...data.target.to, ...data.target.cc, ...data.target.bcc]);
     for (const recipient of targetRecipients) {
       if (originalDomains.has(recipient.domain)) {
         continue;

--- a/tests/unit/test-added-domains-reconfirmation.mjs
+++ b/tests/unit/test-added-domains-reconfirmation.mjs
@@ -6,11 +6,15 @@
 'use strict';
 
 import { AddedDomainsReconfirmation } from "../../src/web/added-domains-reconfirmation.mjs";
+import * as RecipientParser from "../../src/web/recipient-parser.mjs";
 import { assert } from 'tiny-esm-test-runner';
 const { ok, ng, is } = assert;
 
 function toTarget(address) {
-  return { emailAddress: address };
+  return { 
+    emailAddress: address,
+    ...RecipientParser.parse(address),
+   };
 }
 
 test_shouldReconfirm.parameters = {


### PR DESCRIPTION
`to`/`cc`/`bcc` are parsed at `getXXAsync`, so we don't need to parse them again in AddedDomainsReconfirmation.