### PR TITLE
Fix a bug that the confirmation dialog for a new mail doesn't work

### DIFF
--- a/src/web/added-domains-reconfirmation.mjs
+++ b/src/web/added-domains-reconfirmation.mjs
@@ -14,9 +14,9 @@ export class AddedDomainsReconfirmation {
     if (!data.originalRecipients) {
       return;
     }
-    const originalToDomains = data.originalRecipients.to.map((_) => _.domain);
-    const originalCcDomains = data.originalRecipients.cc.map((_) => _.domain);
-    const originalBccDomains = data.originalRecipients.bcc.map((_) => _.domain);
+    const originalToDomains = data.originalRecipients.to?.map((_) => _.domain) ?? [];
+    const originalCcDomains = data.originalRecipients.cc?.map((_) => _.domain) ?? [];
+    const originalBccDomains = data.originalRecipients.bcc?.map((_) => _.domain) ?? [];
     const originalDomains = new Set([...originalToDomains, ...originalCcDomains, ...originalBccDomains]);
     if (originalDomains.size === 0) {
       return;


### PR DESCRIPTION
On a new mail, `data.originalRecipients.to` is `undefined`, and `data.originalRecipients.to.map(...)` raises an invalid member access error. We need to check if `to` is `undefined` or not.
You need to check `cc` and `bcc` as well.

* [x] Confirm that the confirmation dialog for new mail work fine.
* [x] Confirm that the warning for newly added domains are worked fine.