### PR TITLE
Fix a bug on no setting file

### DIFF
--- a/src/web/config-loader.mjs
+++ b/src/web/config-loader.mjs
@@ -94,8 +94,12 @@ export class ConfigLoader {
     console.debug("loadFile ", url);
     try {
       const response = await fetch(url);
+      console.debug("response:", response);
+      if (!response.ok)
+      {
+        return null;
+      }
       const data = await response.text();
-      console.debug(data);
       return data;
     } catch (err) {
       console.error(err);


### PR DESCRIPTION
When a setting file does not exist, we unintentionally regarded the content as "404 Page not found", but we should regard it as an empty setting.

![image](https://github.com/user-attachments/assets/9c6f2550-741b-4bb4-bfd4-c751989c6a52)

## Test

* Execute `test\run-test-server\run-test-server-.bat`
* Remove `test\run-test-server\congis\*.txt`
* Open Outlook
* Open FlexConfirmMail setting dialog
* Select "Configure Trusted Domains and Addresses" tab
  * [x] Confirm that the template for no policy setting or only current user config are used.
  * [x] Confirm that "404 Page not found" is not shown,
* Select "Configure Unsafe Domains and Addresses" tab
  * [x] Confirm that the template for no policy setting or only current user config are used.
  * [x] Confirm that "404 Page not found" is not shown,
* Select "Configure Unsafe Files" tab
  * [x] Confirm that the template for no policy setting or only current user config are used.
  * [x] Confirm that "404 Page not found" is not shown,