### PR TITLE
Add support for comments in the setting dialog

### DIFF
--- a/src/web/app.js
+++ b/src/web/app.js
@@ -219,10 +219,10 @@ async function openDialog({ url, data, asyncContext, promptBeforeOpen, ...params
         // should get the current config from the dialog message and save it in this function.
         const config = messageFromDialog.config ?? {};
         console.debug("user config: ", config);
-        Office.context.roamingSettings.set("common", config.common ?? "");
-        Office.context.roamingSettings.set("trustedDomains", config.trustedDomains ?? "");
-        Office.context.roamingSettings.set("unsafeDomains", config.unsafeDomains ?? "");
-        Office.context.roamingSettings.set("unsafeFiles", config.unsafeFiles ?? "");
+        Office.context.roamingSettings.set("Common", config.commonString ?? "");
+        Office.context.roamingSettings.set("TrustedDomains", config.trustedDomainsString ?? "");
+        Office.context.roamingSettings.set("UnsafeDomains", config.unsafeDomainsString ?? "");
+        Office.context.roamingSettings.set("UnsafeFiles", config.unsafeFilesString ?? "");
         Office.context.roamingSettings.saveAsync((saveResult) => {
           // This function should return (resolve) after finishing saveAsync.
           // If returing before finishing saveAsync, roamingSettings is not

--- a/src/web/config-loader.mjs
+++ b/src/web/config-loader.mjs
@@ -130,7 +130,7 @@ export class ConfigLoader {
         return "";
       }
       const data = await response.text();
-      return data;
+      return data.trim();
     } catch (err) {
       console.error(err);
       return "";
@@ -144,16 +144,12 @@ export class ConfigLoader {
   }
 
   static async loadFileConfig() {
-    let [trustedDomainsString, unsafeDomainsString, unsafeFilesString, commonString] = await Promise.all([
+    const [trustedDomainsString, unsafeDomainsString, unsafeFilesString, commonString] = await Promise.all([
       this.loadFile("configs/TrustedDomains.txt"),
       this.loadFile("configs/UnsafeDomains.txt"),
       this.loadFile("configs/UnsafeFiles.txt"),
       this.loadFile("configs/Common.txt"),
     ]);
-    trustedDomainsString = trustedDomainsString.trim();
-    unsafeDomainsString = unsafeDomainsString.trim();
-    unsafeFilesString = unsafeFilesString.trim();
-    commonString = commonString.trim();
     const trustedDomains = this.toArray(trustedDomainsString);
     const unsafeDomains = this.toArray(unsafeDomainsString);
     const unsafeFiles = this.toArray(unsafeFilesString);
@@ -178,14 +174,10 @@ export class ConfigLoader {
    * @returns user data hash
    */
   static async loadUserConfig() {
-    let trustedDomainsString = Office.context.roamingSettings.get("TrustedDomains") ?? "";
-    let unsafeDomainsString = Office.context.roamingSettings.get("UnsafeDomains") ?? "";
-    let unsafeFilesString = Office.context.roamingSettings.get("UnsafeFiles") ?? "";
-    let commonString = Office.context.roamingSettings.get("Common") ?? "";
-    trustedDomainsString = trustedDomainsString.trim();
-    unsafeDomainsString = unsafeDomainsString.trim();
-    unsafeFilesString = unsafeFilesString.trim();
-    commonString = commonString.trim();
+    const trustedDomainsString = Office.context.roamingSettings.get("TrustedDomains")?.trim() ?? "";
+    const unsafeDomainsString = Office.context.roamingSettings.get("UnsafeDomains")?.trim() ?? "";
+    const unsafeFilesString = Office.context.roamingSettings.get("UnsafeFiles")?.trim() ?? "";
+    const commonString = Office.context.roamingSettings.get("Common")?.trim() ?? "";
     const trustedDomains = this.toArray(trustedDomainsString);
     const unsafeDomains = this.toArray(unsafeDomainsString);
     const unsafeFiles = this.toArray(unsafeFilesString);

--- a/src/web/setting.js
+++ b/src/web/setting.js
@@ -37,7 +37,7 @@ function createDisplayTrustedDomains() {
   }
 }
 
-function serializeSaveTrustedDomains() {
+function serializeTrustedDomains() {
   let trustedDomainsString = document.getElementById("trustedDomainsTextArea").value ?? "";
   if (policyConfig.trustedDomains && policyConfig.trustedDomains.length > 0) {
     const policyDomainsString = policyConfig.trustedDomains?.join("\n# ") ?? "";
@@ -71,7 +71,7 @@ function createDisplayUnsafeDomains() {
   }
 }
 
-function serializeSaveUnsafeDomains() {
+function serializeUnsafeDomains() {
   let unsafeDomainsString = document.getElementById("unsafeDomainsTextArea").value ?? "";
   if (policyConfig.unsafeDomains && policyConfig.unsafeDomains.length > 0) {
     const policyDomainsString = policyConfig.unsafeDomains?.join("\n# ") ?? "";
@@ -225,8 +225,8 @@ function serializeCommonConfigs() {
 window.onSave = () => {
   console.debug("onSave");
   const commonString = serializeCommonConfigs();
-  const trustedDomainsString = serializeSaveTrustedDomains();
-  const unsafeDomainsString = serializeSaveUnsafeDomains();
+  const trustedDomainsString = serializeTrustedDomains();
+  const unsafeDomainsString = serializeUnsafeDomains();
   const unsafeFilesString = serializeUnsafeFiles();
   console.debug("commonString: ", commonString);
   console.debug("trustedDomainsString: ", trustedDomainsString);

--- a/src/web/setting.js
+++ b/src/web/setting.js
@@ -19,49 +19,106 @@ Office.onReady(() => {
   sendStatusToParent("ready");
 });
 
-function createTrustedDomainsString(policy, user) {
-  if (policy.trustedDomains && policy.trustedDomains.length > 0) {
-    const policyDomainsString = policy.trustedDomains?.join("\n# ") ?? "";
-    const userDomainsString = user.trustedDomains?.join("\n") ?? l10n.get("setting_trustedDomainsExample");
+function createDisplayTrustedDomains() {
+  if (policyConfig.trustedDomains && policyConfig.trustedDomains.length > 0) {
+    const policyDomainsString = policyConfig.trustedDomains?.join("\n# ") ?? "";
+    let userDomainsString = userConfig.trustedDomainsString?.trim() ?? "";
+    if (!userDomainsString) {
+      userDomainsString = l10n.get("setting_trustedDomainsExample");
+    }
     return l10n.get("setting_trustedDomainsPolicy", {
       policy: policyDomainsString,
       user: userDomainsString,
     });
-  } else if (user.trustedDomains && user.trustedDomains.length > 0) {
-    return user.trustedDomains.join("\n");
+  } else if (userConfig.trustedDomainsString) {
+    return userConfig.trustedDomainsString;
   } else {
     return l10n.get("setting_trustedDomainsTemplate");
   }
 }
 
-function createUnsafeDomainsString(policy, user) {
-  if (policy.unsafeDomains && policy.unsafeDomains.length > 0) {
-    const policyUnsafeDomainsString = policy.unsafeDomains?.join("\n# ") ?? "";
-    const userUnsafeDomainsString = user.unsafeDomains?.join("\n") ?? l10n.get("setting_unsafeDomainsExample");
+function serializeSaveTrustedDomains() {
+  let trustedDomainsString = document.getElementById("trustedDomainsTextArea").value ?? "";
+  if (policyConfig.trustedDomains && policyConfig.trustedDomains.length > 0) {
+    const policyDomainsString = policyConfig.trustedDomains?.join("\n# ") ?? "";
+    const template = l10n
+      .get("setting_trustedDomainsPolicy", {
+        policy: policyDomainsString,
+        user: "",
+      })
+      .trim();
+    trustedDomainsString = trustedDomainsString.replace(template, "");
+  }
+  trustedDomainsString = trustedDomainsString.trim();
+  return trustedDomainsString;
+}
+
+function createDisplayUnsafeDomains() {
+  if (policyConfig.unsafeDomains && policyConfig.unsafeDomains.length > 0) {
+    const policyUnsafeDomainsString = policyConfig.unsafeDomains?.join("\n# ") ?? "";
+    let userUnsafeDomainsString = userConfig.unsafeDomainsString?.trim() ?? "";
+    if (!userUnsafeDomainsString) {
+      userUnsafeDomainsString = l10n.get("setting_unsafeDomainsExample");
+    }
     return l10n.get("setting_unsafeDomainsPolicy", {
       policy: policyUnsafeDomainsString,
       user: userUnsafeDomainsString,
     });
-  } else if (user.unsafeDomains && user.unsafeDomains.length > 0) {
-    return user.unsafeDomains.join("\n");
+  } else if (userConfig.unsafeDomainsString) {
+    return userConfig.unsafeDomainsString;
   } else {
     return l10n.get("setting_unsafeDomainsTemplate");
   }
 }
 
-function createUnsafeFilesString(policy, user) {
-  if (policy.unsafeFiles && policy.unsafeFiles.length > 0) {
-    const policyUnsafeFilesString = policy.unsafeFiles?.join("\n# ") ?? "";
-    const userUnsafeFilesString = user.unsafeFiles?.join("\n") ?? l10n.get("setting_unsafeFilesExample");
+function serializeSaveUnsafeDomains() {
+  let unsafeDomainsString = document.getElementById("unsafeDomainsTextArea").value ?? "";
+  if (policyConfig.unsafeDomains && policyConfig.unsafeDomains.length > 0) {
+    const policyDomainsString = policyConfig.unsafeDomains?.join("\n# ") ?? "";
+    const template = l10n
+      .get("setting_unsafeDomainsPolicy", {
+        policy: policyDomainsString,
+        user: "",
+      })
+      .trim();
+    unsafeDomainsString = unsafeDomainsString.replace(template, "");
+  }
+  unsafeDomainsString = unsafeDomainsString.trim();
+  return unsafeDomainsString;
+}
+
+function createDisplayUnsafeFiles() {
+  if (policyConfig.unsafeFiles && policyConfig.unsafeFiles.length > 0) {
+    const policyUnsafeFilesString = policyConfig.unsafeFiles?.join("\n# ") ?? "";
+    let userUnsafeFilesString = userConfig.unsafeFilesString?.trim() ?? "";
+    if (!userUnsafeFilesString) {
+      userUnsafeFilesString = l10n.get("setting_unsafeFilesExample");
+    }
     return l10n.get("setting_unsafeFilesPolicy", {
       policy: policyUnsafeFilesString,
       user: userUnsafeFilesString,
     });
-  } else if (user.unsafeFiles && user.unsafeFiles.length > 0) {
-    return user.unsafeFiles.join("\n");
+  } else if (userConfig.unsafeFilesString) {
+    return userConfig.unsafeFilesString;
   } else {
     return l10n.get("setting_unsafeFilesTemplate");
   }
+}
+
+function serializeUnsafeFiles() {
+  let unsafeFilesString = document.getElementById("unsafeFilesTextArea").value ?? "";
+  if (policyConfig.unsafeFiles && policyConfig.unsafeFiles.length > 0) {
+    const policyUnsafeFilesString = policyConfig.unsafeFiles?.join("\n# ") ?? "";
+    const template = l10n
+      .get("setting_unsafeFilesPolicy", {
+        policy: policyUnsafeFilesString,
+        user: "",
+      })
+      .trim();
+    unsafeFilesString = unsafeFilesString.replace(template, "");
+  }
+  unsafeFilesString = unsafeFilesString.trim();
+  return unsafeFilesString;
 }
 
 async function onMessageFromParent(arg) {
@@ -69,6 +126,7 @@ async function onMessageFromParent(arg) {
     return;
   }
   const configs = JSON.parse(arg.message);
+  console.debug("configs: ", configs);
   if (!configs) {
     return;
   }
@@ -84,9 +142,9 @@ function updateDialogSetting(policy, user) {
   console.debug(effectiveConfig);
   const common = effectiveConfig.common;
   const fixedParametersSet = new Set(policyConfig.common.FixedParameters ?? []);
-  const trustedDomainsString = createTrustedDomainsString(policyConfig, userConfig);
-  const unsafeDomainsString = createUnsafeDomainsString(policyConfig, userConfig);
-  const unsafeFilesString = createUnsafeFilesString(policyConfig, userConfig);
+  const trustedDomainsString = createDisplayTrustedDomains();
+  const unsafeDomainsString = createDisplayUnsafeDomains();
+  const unsafeFilesString = createDisplayUnsafeFiles();
 
   document.getElementById("trustedDomainsTextArea").value = trustedDomainsString;
   document.getElementById("trustedDomainsTextArea").disabled = fixedParametersSet.has("TrustedDomains");
@@ -166,19 +224,19 @@ function serializeCommonConfigs() {
 
 window.onSave = () => {
   console.debug("onSave");
-  const common = serializeCommonConfigs();
-  const trustedDomains = document.getElementById("trustedDomainsTextArea").value ?? "";
-  const unsafeDomains = document.getElementById("unsafeDomainsTextArea").value ?? "";
-  const unsafeFiles = document.getElementById("unsafeFilesTextArea").value ?? "";
-  console.debug("common: " + common);
-  console.debug("trustedDomains: " + trustedDomains);
-  console.debug("unsafeDomains: " + unsafeDomains);
-  console.debug("unsafeFiles: " + unsafeFiles);
+  const commonString = serializeCommonConfigs();
+  const trustedDomainsString = serializeSaveTrustedDomains();
+  const unsafeDomainsString = serializeSaveUnsafeDomains();
+  const unsafeFilesString = serializeUnsafeFiles();
+  console.debug("commonString: ", commonString);
+  console.debug("trustedDomainsString: ", trustedDomainsString);
+  console.debug("unsafeDomainsString: ", unsafeDomainsString);
+  console.debug("unsafeFilesString: ", unsafeFilesString);
   const config = {
-    common,
-    trustedDomains,
-    unsafeDomains,
-    unsafeFiles,
+    commonString,
+    trustedDomainsString,
+    unsafeDomainsString,
+    unsafeFilesString,
   };
   sendConfigToParent(config);
 };

--- a/tests/unit/test-config-loader.mjs
+++ b/tests/unit/test-config-loader.mjs
@@ -287,6 +287,10 @@ export function test_createDefaultConfig() {
       trustedDomains: [],
       unsafeDomains: [],
       unsafeFiles: [],
+      commonString: "",
+      trustedDomainsString: "",
+      unsafeDomainsString: "",
+      unsafeFilesString: "",
     },
     ConfigLoader.createDefaultConfig()
   );
@@ -299,11 +303,14 @@ export function test_createEmptyConfig() {
       trustedDomains: [],
       unsafeDomains: [],
       unsafeFiles: [],
+      commonString: "",
+      trustedDomainsString: "",
+      unsafeDomainsString: "",
+      unsafeFilesString: "",
     },
     ConfigLoader.createEmptyConfig()
   );
 }
-
 
 test_merge.parameters = {
   "left is empty": {
@@ -312,6 +319,10 @@ test_merge.parameters = {
       trustedDomains: [],
       unsafeDomains: [],
       unsafeFiles: [],
+      commonString: "",
+      trustedDomainsString: "",
+      unsafeDomainsString: "",
+      unsafeFilesString: "",
     },
     right: {
       common: {
@@ -329,6 +340,10 @@ test_merge.parameters = {
       trustedDomains: ["trustedDomain"],
       unsafeDomains: ["unsafeDomain"],
       unsafeFiles: ["unsafeFile"],
+      commonString: "CountEnabled = true\nCountAllowSkip = true\nSafeBccEnabled = true\nMainSkipIfNoExt = true\nSafeNewDomainsEnabled = true\nCountSeconds = 3\nSafeBccThreshold = 4\nDelayDeliveryEnabled = true\nDelayDeliverySeconds = 60",
+      trustedDomainsString: "trustedDomain",
+      unsafeDomainsString: "unsafeDomain",
+      unsafeFilesString: "unsafeFile",
     },
     expected: {
       common: {
@@ -346,6 +361,10 @@ test_merge.parameters = {
       trustedDomains: ["trustedDomain"],
       unsafeDomains: ["unsafeDomain"],
       unsafeFiles: ["unsafeFile"],
+      commonString: "CountEnabled = true\nCountAllowSkip = true\nSafeBccEnabled = true\nMainSkipIfNoExt = true\nSafeNewDomainsEnabled = true\nCountSeconds = 3\nSafeBccThreshold = 4\nDelayDeliveryEnabled = true\nDelayDeliverySeconds = 60",
+      trustedDomainsString: "trustedDomain",
+      unsafeDomainsString: "unsafeDomain",
+      unsafeFilesString: "unsafeFile",
     }
   },
   "right is empty": {
@@ -365,12 +384,20 @@ test_merge.parameters = {
       trustedDomains: ["trustedDomain"],
       unsafeDomains: ["unsafeDomain"],
       unsafeFiles: ["unsafeFile"],
+      commonString: "CountEnabled = true\nCountAllowSkip = true\nSafeBccEnabled = true\nMainSkipIfNoExt = true\nSafeNewDomainsEnabled = true\nCountSeconds = 3\nSafeBccThreshold = 4\nDelayDeliveryEnabled = true\nDelayDeliverySeconds = 60",
+      trustedDomainsString: "trustedDomain",
+      unsafeDomainsString: "unsafeDomain",
+      unsafeFilesString: "unsafeFile",
     },
     right: {
       common: {},
       trustedDomains: [],
       unsafeDomains: [],
       unsafeFiles: [],
+      commonString: "",
+      trustedDomainsString: "",
+      unsafeDomainsString: "",
+      unsafeFilesString: "",
     },
     expected: {
       common: {
@@ -388,6 +415,10 @@ test_merge.parameters = {
       trustedDomains: ["trustedDomain"],
       unsafeDomains: ["unsafeDomain"],
       unsafeFiles: ["unsafeFile"],
+      commonString: "CountEnabled = true\nCountAllowSkip = true\nSafeBccEnabled = true\nMainSkipIfNoExt = true\nSafeNewDomainsEnabled = true\nCountSeconds = 3\nSafeBccThreshold = 4\nDelayDeliveryEnabled = true\nDelayDeliverySeconds = 60",
+      trustedDomainsString: "trustedDomain",
+      unsafeDomainsString: "unsafeDomain",
+      unsafeFilesString: "unsafeFile",
     }
   },
   "use right defined params": {
@@ -407,6 +438,10 @@ test_merge.parameters = {
       trustedDomains: ["trustedDomain_left"],
       unsafeDomains: ["unsafeDomain_left"],
       unsafeFiles: ["unsafeFile_left"],
+      commonString: "CountEnabled = true\nCountAllowSkip = true\nSafeBccEnabled = true\nMainSkipIfNoExt = true\nSafeNewDomainsEnabled = true\nCountSeconds = 3\nSafeBccThreshold = 4\nDelayDeliveryEnabled = true\nDelayDeliverySeconds = 60",
+      trustedDomainsString: "trustedDomain_left",
+      unsafeDomainsString: "unsafeDomain_left",
+      unsafeFilesString: "unsafeFile_left",
     },
     right: {
       common: {
@@ -424,6 +459,10 @@ test_merge.parameters = {
       trustedDomains: ["trustedDomain_right"],
       unsafeDomains: ["unsafeDomain_right"],
       unsafeFiles: ["unsafeFile_right"],
+      commonString: "CountEnabled = false\nCountAllowSkip = false\nSafeBccEnabled = false\nMainSkipIfNoExt = false\nSafeNewDomainsEnabled = false\nCountSeconds = 2\nSafeBccThreshold = 2\nDelayDeliveryEnabled = false\nDelayDeliverySeconds = 10\nFixedParameters = CountSeconds",
+      trustedDomainsString: "trustedDomain_right",
+      unsafeDomainsString: "unsafeDomain_right",
+      unsafeFilesString: "unsafeFile_right",
     },
     expected: {
       common: {
@@ -441,6 +480,10 @@ test_merge.parameters = {
       trustedDomains: ["trustedDomain_left", "trustedDomain_right"],
       unsafeDomains: ["unsafeDomain_left", "unsafeDomain_right"],
       unsafeFiles: ["unsafeFile_left", "unsafeFile_right"],
+      commonString: "CountEnabled = false\nCountAllowSkip = false\nSafeBccEnabled = false\nMainSkipIfNoExt = false\nSafeNewDomainsEnabled = false\nCountSeconds = 2\nSafeBccThreshold = 2\nDelayDeliveryEnabled = false\nDelayDeliverySeconds = 10\nFixedParameters = CountSeconds",
+      trustedDomainsString: "trustedDomain_left\ntrustedDomain_right",
+      unsafeDomainsString: "unsafeDomain_left\nunsafeDomain_right",
+      unsafeFilesString: "unsafeFile_left\nunsafeFile_right",
     },
   },
   "fix all parameters": {
@@ -473,6 +516,10 @@ test_merge.parameters = {
       trustedDomains: ["trustedDomain_left"],
       unsafeDomains: ["unsafeDomain_left"],
       unsafeFiles: ["unsafeFile_left"],
+      commonString: "CountEnabled = true\nCountAllowSkip = true\nSafeBccEnabled = true\nMainSkipIfNoExt = true\nSafeNewDomainsEnabled = true\nCountSeconds = 3\nSafeBccThreshold = 4\nDelayDeliveryEnabled = true\nDelayDeliverySeconds = 60\nFixedParameters = CountEnabled,CountAllowSkip,SafeBccEnabled,MainSkipIfNoExt,SafeNewDomainsEnabled,CountSeconds,SafeBccThreshold,DelayDeliveryEnabled,DelayDeliverySeconds,TrustedDomains,UnsafeDomains,UnsafeFiles",
+      trustedDomainsString: "trustedDomain_left",
+      unsafeDomainsString: "unsafeDomain_left",
+      unsafeFilesString: "unsafeFile_left",
     },
     right: {
       common: {
@@ -490,6 +537,10 @@ test_merge.parameters = {
       trustedDomains: ["trustedDomain_right"],
       unsafeDomains: ["unsafeDomain_right"],
       unsafeFiles: ["unsafeFile_right"],
+      commonString: "CountEnabled = false\nCountAllowSkip = false\nSafeBccEnabled = false\nMainSkipIfNoExt = false\nSafeNewDomainsEnabled = false\nCountSeconds = 2\nSafeBccThreshold = 2\nDelayDeliveryEnabled = false\nDelayDeliverySeconds = 10\nFixedParameters = CountSeconds",
+      trustedDomainsString: "trustedDomain_right",
+      unsafeDomainsString: "unsafeDomain_right",
+      unsafeFilesString: "unsafeFile_right",
     },
     expected: {
       common: {
@@ -520,6 +571,10 @@ test_merge.parameters = {
       trustedDomains: ["trustedDomain_left"],
       unsafeDomains: ["unsafeDomain_left"],
       unsafeFiles: ["unsafeFile_left"],
+      commonString: "CountEnabled = true\nCountAllowSkip = true\nSafeBccEnabled = true\nMainSkipIfNoExt = true\nSafeNewDomainsEnabled = true\nCountSeconds = 3\nSafeBccThreshold = 4\nDelayDeliveryEnabled = true\nDelayDeliverySeconds = 60\nFixedParameters = CountEnabled,CountAllowSkip,SafeBccEnabled,MainSkipIfNoExt,SafeNewDomainsEnabled,CountSeconds,SafeBccThreshold,DelayDeliveryEnabled,DelayDeliverySeconds,TrustedDomains,UnsafeDomains,UnsafeFiles",
+      trustedDomainsString: "trustedDomain_left",
+      unsafeDomainsString: "unsafeDomain_left",
+      unsafeFilesString: "unsafeFile_left",
     },
   },
 }


### PR DESCRIPTION
The original config strings are added to the config object which have comments on having saved. 
We use that strings when displaying the config. 
Also, we serialize that strings to roamingSettings in order to save user comments.

## Test

* Open the FlexConfirmMail setting dialog.
* Open "社内ドメイン・アドレス"
* Add some entries with comments
  * E.g.
    ```
    # comment1
    a@example.com
    ```
* Open "注意が必要なドメイン・アドレス"
* Add some entries with comments
  * E.g.
    ```
    # comment2
    b@example.com
    ```
* Open "注意が必要なファイル名"
* Add some entries with comments
  * E.g.
    ```
    # comment3
    c@example.com
    ```
* Click "保存して閉じる"
* Open the FlexConfirmMail setting dialog.
* Open "社内ドメイン・アドレス"
* [x] Confirm that entries are same as having added with the previous procedure including comments.
  * E.g.
    ```
    # comment1
    a@example.com
    ```
* Open "注意が必要なドメイン・アドレス"
* [x] Confirm that entries are same as having added with the previous procedure including comments.
  * E.g.
    ```
    # comment2
    b@example.com
    ```
* Open  "注意が必要なファイル名"
* [x] Confirm that entries are same as having added with the previous procedure including comments.
  * E.g.
    ```
    # comment3
    c@example.com
    ```
