### PR TITLE
Add fallback modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "scripts": {
     "build": "webpack --mode production",
     "build:dev": "webpack --mode development",
+    "build:fallback": "webpack --config webpack.config.fallback.js --mode production",
     "dev-server": "webpack serve --mode development",
     "lint": "office-addin-lint check --files src/**/*.{js,mjs}",
     "lint:fix": "office-addin-lint fix --files src/**/*.{js,mjs}",

--- a/src/web-fallback/app.html
+++ b/src/web-fallback/app.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>No title</title>
+    <meta http-equiv="X-UA-Compatible" content="IE=Edge">
+    <script src="lib/office-js/office.js" type="text/javascript"></script>
+</head>
+<body>
+</body>
+</html>

--- a/src/web-fallback/app.js
+++ b/src/web-fallback/app.js
@@ -1,0 +1,20 @@
+Office.onReady(() => {
+});
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+async function onItemSend(event) {
+  event.completed({ allowEvent: true });
+}
+window.onItemSend = onItemSend;
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+async function onNewMessageComposeCreated(event) {
+  event.completed();
+}
+window.onNewMessageComposeCreated = onNewMessageComposeCreated;
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+async function onOpenSettingDialog(event) {
+  event.completed({ allowEvent: true });
+}
+window.onOpenSettingDialog = onOpenSettingDialog;

--- a/src/web-fallback/app.js
+++ b/src/web-fallback/app.js
@@ -1,5 +1,4 @@
-Office.onReady(() => {
-});
+Office.onReady(() => {});
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 async function onItemSend(event) {

--- a/webpack.config.fallback.js
+++ b/webpack.config.fallback.js
@@ -1,0 +1,91 @@
+/* eslint-disable no-undef */
+
+const path = require('path');
+const devCerts = require("office-addin-dev-certs");
+const CopyWebpackPlugin = require("copy-webpack-plugin");
+const HtmlWebpackPlugin = require("html-webpack-plugin");
+
+const urlDev = "https://127.0.0.1:10041/";
+const urlProd = "https://127.0.0.1:10041/"; // CHANGE THIS TO YOUR PRODUCTION DEPLOYMENT LOCATION
+
+async function getHttpsOptions() {
+  const httpsOptions = await devCerts.getHttpsServerOptions();
+  return { ca: httpsOptions.ca, key: httpsOptions.key, cert: httpsOptions.cert };
+}
+
+module.exports = async (env, options) => {
+  const dev = options.mode === "development";
+  const config = {
+    devtool: "source-map",
+    entry: {
+      app: ["./src/web-fallback/app.js"],
+    },
+    output: {
+      path: path.resolve('dist-fallback/'),
+      clean: true,
+    },
+    resolve: {
+      extensions: [".html", ".js"],
+    },
+    module: {
+      rules: [
+        {
+          test: /\.m?js$/,
+          exclude: /node_modules/,
+          use: {
+            loader: "babel-loader",
+            options: {
+              presets: ["@babel/preset-env"],
+            },
+          },
+        },
+        {
+          test: /\.(png|jpg|jpeg|gif|ico)$/,
+          type: "asset/resource",
+          generator: {
+            filename: "assets/[name][ext][query]",
+          },
+        },
+      ],
+    },
+    plugins: [
+      new HtmlWebpackPlugin({
+        filename: "app.html",
+        template: "./src/web-fallback/app.html",
+        chunks: ["app"],
+      }),
+      new CopyWebpackPlugin({
+        patterns: [
+          {
+            from: "assets/*",
+            to: "assets/[name][ext][query]",
+          },
+          {
+            from: "node_modules/@microsoft/office-js/dist",
+            to: "lib/office-js",
+          },
+          {
+            from: "node_modules/@microsoft/office-js/LICENSE.md",
+            to: "lib/office-js/LICENSE.md",
+          },
+        ],
+      }),
+
+    ],
+    devServer: {
+      headers: {
+        "Access-Control-Allow-Origin": "*",
+      },
+      server: {
+        type: "https",
+        options: env.WEBPACK_BUILD || options.https !== undefined ? options.https : await getHttpsOptions(),
+      },
+      port: process.env.npm_package_config_dev_server_port || 10041,
+    },
+    optimization:{
+      minimize: false
+    },
+  };
+
+  return config;
+};


### PR DESCRIPTION
Prepare fallback modules in case a failure occurs in the web server during operation.

The fallback modules simply allow all events.

We can build fallback modules with `npm run build:fallback`.
The build result is output to the `dist-fallback` folder.

### Test

* Register FlexConfirmMail to Outlook
* Execute `npm run build:fallback`
* Execute web server with `dist-fallback`
  ```
  cd tests\run-test-server
  https-server.exe --root ..\..\dist-fallback
  ```
* Open Message -> Apps
  * [x] Confirm that the FlexConfirmMail icon is displayed
* Open the FlexConfirmMail setting dialog on Outlook
  * [x] Confirm that nothing happen 
* Send a mail to `a@example.com`
  * [x] Confirm that the mail is sent with no confirmation dialog.