### PR TITLE
Improve countdown dialog UI

### DIFF
--- a/src/web/confirm.html
+++ b/src/web/confirm.html
@@ -9,7 +9,7 @@
     <link href="dialog.css" rel="stylesheet">
     <link href="confirm.css" rel="stylesheet">
 </head>
-<body>
+<body class="dialog-body">
     <div class="card-container">
         <div class="cards">
             <fluent-card>

--- a/src/web/count-down.html
+++ b/src/web/count-down.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html>
+
 <head>
     <title>Confirmation</title>
     <meta http-equiv="X-UA-Compatible" content="IE=Edge">
@@ -9,22 +10,23 @@
     <link href="dialog.css" rel="stylesheet">
     <link href="count-down.css" rel="stylesheet">
 </head>
-<body>
-    <div class="card-container">
-        <div class="cards">
-            <fluent-card>
-                <p id="message" hidden>
-                  <span data-l10n-text-content="countDown_messageBefore"></span>
-                  <span id="count"></span>
-                  <span data-l10n-text-content="countDown_messageAfter"></span></p>
-            </fluent-card>
-        </div>
+
+<body class="dialog-body">
+    <div class="dialog-content">
+        <p id="message" hidden>
+            <span data-l10n-text-content="countDown_messageBefore"></span>
+            <span id="count"></span>
+            <span data-l10n-text-content="countDown_messageAfter"></span>
+        </p>
+    </div>
+    <div class="dialog-footer">
         <div class="button-container">
             <fluent-button id="send-button" onclick="onSend()"
-                           data-l10n-text-content="countDown_sendButtonLabel"></fluent-button>
+                data-l10n-text-content="countDown_sendButtonLabel"></fluent-button>
             <fluent-button id="cancel-button" onclick="onCancel()"
-                           data-l10n-text-content="countDown_cancelButtonLabel"></fluent-button>
+                data-l10n-text-content="countDown_cancelButtonLabel"></fluent-button>
         </div>
     </div>
 </body>
+
 </html>

--- a/src/web/dialog.css
+++ b/src/web/dialog.css
@@ -32,4 +32,5 @@ fluent-divider {
   flex-direction: column;
   height: 100%;
   padding: 0;
+  margin: 0;
 }

--- a/src/web/dialog.mjs
+++ b/src/web/dialog.mjs
@@ -7,10 +7,14 @@
 
 export function resizeToContent() {
   const range = document.createRange();
-  range.selectNodeContents(document.querySelector(".card-container"));
+  const element = document.querySelector(".dialog-body");
+  range.selectNodeContents(element);
   const contentsRect = range.getBoundingClientRect();
+  const styles = window.getComputedStyle(element);
+  const marginTop = parseFloat(styles.marginTop) || 0;
+  const marginBottom = parseFloat(styles.marginBottom) || 0;
 
   const widthDelta = contentsRect.width - window.innerWidth;
-  const heightDelta = contentsRect.height - window.innerHeight;
+  const heightDelta = contentsRect.height + marginTop + marginBottom - window.innerHeight;
   window.resizeBy(Math.min(0, widthDelta), Math.min(0, heightDelta));
 }

--- a/src/web/setting.css
+++ b/src/web/setting.css
@@ -1,7 +1,6 @@
 html, body {
   height: 100%;
   width: 100%;
-  margin: 0;
   overflow: hidden;
 }
 


### PR DESCRIPTION
Improve countdown dialog UI

## Overview

The original countdown dialog was below.

![image](https://github.com/user-attachments/assets/02a559aa-47ab-4db2-8971-fe9fc1f6fabf)

The right side seek bar was obstacle ( We didn't resize the dialog correctly ).
Also I feel like the card for the countdown number is not necessary.

The modified countdown dialog is below.

![image](https://github.com/user-attachments/assets/0e993797-9fc9-40cf-8aff-ea91e939358a)

## Detail

* Fix to use `.dialog-body`, `.dialog-contents` and `dialog-footer` for the countdown dialog.
* Do not use the card style.
  * It seems the card style does not match
* Modify resizing logic as to add top and bottom margins.
  * `range.selectNodeContents` does not contains margins.
* Set margins 0 for dialog body.
  * User clients add margins to the `body` tag of the dialog, but we don't want it.

## Test

* Confirm that the countdown dialog is modified.

![image](https://github.com/user-attachments/assets/0e993797-9fc9-40cf-8aff-ea91e939358a)
