### PR TITLE
Fix no default value used bug

### DIFF
--- a/src/web/config-loader.mjs
+++ b/src/web/config-loader.mjs
@@ -139,7 +139,8 @@ export class ConfigLoader {
 
   static async loadEffectiveConfig() {
     const [fileConfig, userConfig] = await Promise.all([this.loadFileConfig(), this.loadUserConfig()]);
-    const effectiveConfig = await this.merge(fileConfig, userConfig);
+    const effectiveFileConfig = this.merge(this.createDefaultConfig(), fileConfig);
+    const effectiveConfig = this.merge(effectiveFileConfig, userConfig);
     return effectiveConfig;
   }
 


### PR DESCRIPTION
The system default config is not used for confirmation, so added process to merge the default config for the confirmation effective config.

Config parameters the default value is not false or empty was not working as displayed in the setting dialog.
The config for the setting dialog was included the system default config, but for the confirmation was not.
So, those parameter's behavior while confirmation is not matched to the setting dialog.
They worked as expected only when they were modified (I mean, we specified non-original value) with the file config or user config.
