### PR TITLE
Build fallback modules in build.bat

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -1,4 +1,5 @@
 @echo on
 
 call npm install 
-call npx webpack
+call npm run build
+call npm run build:fallback


### PR DESCRIPTION
Build fallback modules in build.bat.

We need to build fallback modules when releasing.
So add the fallback modules to build target

## Test

* Execute build.bat
  * [x] Confirm that `dist` and `dist-fallback` are built.