### PR TITLE
Countdown: fix to send a mail when the "send now" button is clicked

### DIFF
--- a/src/web/app.js
+++ b/src/web/app.js
@@ -345,7 +345,7 @@ async function tryCountDown(data, asyncContext) {
   }
 
   return {
-    allowed: status === "ok" || status == "done",
+    allowed: status === "ok" || status == "done" || status == "skip",
     asyncContext,
   };
 }


### PR DESCRIPTION
Fix to send a mail when the "Send Now" button is clicked.

The countdown dialog close with the status "skip" if  the "Send Now" is clicked.
On the other hand, `app.js` regards only "ok" and "done" as being success.
So added "skip" for being success.

## Test

* Try to send a mail to myself
* Check all check-boxes on the confirmation dialog
* Click the "Send" button
* Click "Send Now" on the countdown dialog
  * [x] Confirm that the mail is sent