### PR TITLE
Specify no-cache to fetch for config files

### DIFF
--- a/src/web/config-loader.mjs
+++ b/src/web/config-loader.mjs
@@ -124,7 +124,7 @@ export class ConfigLoader {
   static async loadFile(url) {
     console.debug("loadFile ", url);
     try {
-      const response = await fetch(url);
+      const response = await fetch(url, { cache: "no-cache" });
       console.debug("response:", response);
       if (!response.ok) {
         return "";


### PR DESCRIPTION
Added "cache: no-cache" option for fetch so that
updated config files are reflected immediately.


## Test

* Enable cache of browser
  * E.g. for Edge
    * Open DevTools by F12
    * Open the Network tab
    * Uncheck "Disable cache"
* Modify "configs\Common.txt" of web server contents to empty
* Start web server
* Open Outlook
* Open FlexConfirmMail setting dialog
  * [x] Confirm that `CountEnabled` is checked
* Close FlexConfirmMail setting dialog by clicking cancel button
* Modify "configs\Common.txt" as below
  * `CountEnabled = False`
* Open FlexConfirmMail setting dialog
  * [x] Confirm that `CountEnabled` is unchecked
* Close FlexConfirmMail setting dialog by clicking cancel button