### PR TITLE
Remove a needless Rule

### DIFF
--- a/FlexConfirmMail.manifest.xml
+++ b/FlexConfirmMail.manifest.xml
@@ -34,7 +34,6 @@
   <Permissions>ReadWriteMailbox</Permissions>
   <Rule xsi:type="RuleCollection" Mode="Or">
     <Rule xsi:type="ItemIs" ItemType="Message" FormType="Edit" />
-    <Rule xsi:type="ItemIs" ItemType="Appointment" FormType="Edit" />
   </Rule>
 
   <VersionOverrides xmlns="http://schemas.microsoft.com/office/mailappversionoverrides" xsi:type="VersionOverridesV1_0">


### PR DESCRIPTION
FlexConfirmMail does not use an appointment type.

## Test

* [x] FlexConfirmMail.manifest.xml is loaded successfully.
