### PR TITLE
Make all FixedParameters independent

### DIFF
--- a/src/web/setting.js
+++ b/src/web/setting.js
@@ -156,8 +156,7 @@ function updateDialogSetting(policy, user) {
   document.getElementById("countEnabled").checked = common.CountEnabled;
   document.getElementById("countEnabled").disabled = fixedParametersSet.has("CountEnabled");
   document.getElementById("countAllowSkip").checked = common.CountAllowSkip;
-  document.getElementById("countAllowSkip").disabled =
-    fixedParametersSet.has("CountEnabled") || fixedParametersSet.has("CountAllowSkip");
+  document.getElementById("countAllowSkip").disabled = fixedParametersSet.has("CountAllowSkip");
   document.getElementById("safeBccEnabled").checked = common.SafeBccEnabled;
   document.getElementById("safeBccEnabled").disabled = fixedParametersSet.has("SafeBccEnabled");
   document.getElementById("mainSkipIfNoExt").checked = common.MainSkipIfNoExt;
@@ -165,16 +164,13 @@ function updateDialogSetting(policy, user) {
   document.getElementById("safeNewDomainsEnabled").checked = common.SafeNewDomainsEnabled;
   document.getElementById("safeNewDomainsEnabled").disabled = fixedParametersSet.has("SafeNewDomainsEnabled");
   document.getElementById("countSeconds").value = common.CountSeconds;
-  document.getElementById("countSeconds").disabled =
-    fixedParametersSet.has("CountEnabled") || fixedParametersSet.has("CountSeconds");
+  document.getElementById("countSeconds").disabled = fixedParametersSet.has("CountSeconds");
   document.getElementById("safeBccThreshold").value = common.SafeBccThreshold;
-  document.getElementById("safeBccThreshold").disabled =
-    fixedParametersSet.has("SafeBccEnabled") || fixedParametersSet.has("SafeBccThreshold");
+  document.getElementById("safeBccThreshold").disabled = fixedParametersSet.has("SafeBccThreshold");
   document.getElementById("delayDeliveryEnabled").checked = common.DelayDeliveryEnabled;
   document.getElementById("delayDeliveryEnabled").disabled = fixedParametersSet.has("DelayDeliveryEnabled");
   document.getElementById("delayDeliverySeconds").value = common.DelayDeliverySeconds;
-  document.getElementById("delayDeliverySeconds").disabled =
-    fixedParametersSet.has("DelayDeliveryEnabled") || fixedParametersSet.has("DelayDeliverySeconds");
+  document.getElementById("delayDeliverySeconds").disabled = fixedParametersSet.has("DelayDeliverySeconds");
 }
 
 function sendStatusToParent(status) {


### PR DESCRIPTION
Some fixed parameters also fixed related other parameters.

* Fixing CountEnabled also fixed CountAllowSkip and CountSeconds.
* Fixing SafeBccEnabled also fixed SafeBccThreshold.
* Fixing DelayDeliveryEnabled also fixed DelayDeliverySeconds.

However, this behavior is somehow not intuitive, so this behavior is deprecated, and all parameters have been made independent.

## Test

* Specify the following params to `configs\Common.txt`
  * `FixedParameters = CountEnabled, SafeBccEnabled, DelayDeliveryEnabled`
* Open the FlexConfirmMail setting dialog.
  * [x] Confirm that only the following parameters are fixed.
    * 「メール送信前のカウントダウンを有効化する」
    * 「遅延送信を有効化する」
    * 「To/CCに一定数以上のドメインが含まれている場合に警告する」