### PR TITLE
Specify no-store for fetch cache

### DIFF
--- a/src/web/config-loader.mjs
+++ b/src/web/config-loader.mjs
@@ -124,7 +124,7 @@ export class ConfigLoader {
   static async loadFile(url) {
     console.debug("loadFile ", url);
     try {
-      const response = await fetch(url, { cache: "no-cache" });
+      const response = await fetch(url, { cache: "no-store" });
       console.debug("response:", response);
       if (!response.ok) {
         return "";


### PR DESCRIPTION
"no-cache" does not use new data if the last modified time is not updated. However, we sometimes update a file by over- writing it with an existing file, and then, if the last modified time of the existing file is old, the last modified time of the target file is not updated. As a result, "fetch" returns not the new file but the old cached file.

By using "no-store", fetch always does not use cache and returns a current file.

FYI: https://developer.mozilla.org/ja/docs/Web/API/Request/cache

## Test

* Create a empty Common.txt to "C:\temp"
* Copy that Common.txt to "configs\Common.txt"
* Add `CountEnabled = False` to Common.txt
* Open the FlexConfirmMail setting dialog
  * [x] Confirm that "メール送信前のカウントダウンを有効化する" is unchecked
* Close the FlexConfirmMail setting dialog
* Copy that Common.txt to "configs\Common.txt"
  * [x] Confirm that the last modified time of `configs\Common.txt` is rewound
* Open the FlexConfirmMail setting dialog
  * [x] Confirm that "メール送信前のカウントダウンを有効化する" is checked