### PR TITLE
Disable "check all" button if there is no trusted domain

### DIFF
--- a/src/web/confirm.html
+++ b/src/web/confirm.html
@@ -18,7 +18,7 @@
                 <fluent-card>
                     <div class="heading-container">
                         <h3 data-l10n-text-content="confirmation_trustedCaption"></h3>
-                        <fluent-button onclick="onCheckAllTrusted()"
+                        <fluent-button id="check-all-trusted" onclick="onCheckAllTrusted()"
                             data-l10n-text-content="confirmation_trustedCheckAllButtonLabel"></fluent-button>
                     </div>
                     <fluent-divider></fluent-divider>

--- a/src/web/confirm.js
+++ b/src/web/confirm.js
@@ -156,6 +156,9 @@ async function onMessageFromParent(arg) {
   console.log(data);
   await Promise.all([l10n.ready, safeBccConfirmation.loaded, attachmentsConfirmation.loaded]);
 
+  if (data.classified.trusted.length == 0) {
+    $("#check-all-trusted").prop("disabled", true);
+  }
   const groupedByTypeTrusteds = Object.groupBy(data.classified.trusted, (item) => item.domain);
   appendRecipientCheckboxes($("#trusted-domains"), groupedByTypeTrusteds);
   const groupedByTypeUntrusted = Object.groupBy(data.classified.untrusted, (item) => item.domain);


### PR DESCRIPTION
The "Check All" button does nothing if there is no trusted domain.
So it is better to disable it it there is no trusted domain.

## Test 

* [x] Confirm that the "Check All" button is disabled if there is no trusted domain
* [x] Confirm that the "Check All" button is enabled if there are one ore more trusted domains