### PR TITLE
Update required Mailbox API version to 1.13

### DIFF
--- a/FlexConfirmMail.manifest.xml
+++ b/FlexConfirmMail.manifest.xml
@@ -41,7 +41,7 @@
     <VersionOverrides xmlns="http://schemas.microsoft.com/office/mailappversionoverrides/1.1" xsi:type="VersionOverridesV1_1">
       <Description resid="residAppDescription" />
       <Requirements>
-        <bt:Sets DefaultMinVersion="1.12">
+        <bt:Sets DefaultMinVersion="1.13">
           <bt:Set Name="Mailbox" />
         </bt:Sets>
       </Requirements>


### PR DESCRIPTION
We now use Office.DelayDeliveryTime and it requires Mailbox API version 1.13+.

https://learn.microsoft.com/ja-jp/javascript/api/outlook/office.delaydeliverytime?view=outlook-js-preview

## Test

* [x] Confirm that we can load FlexConfirmMail.manifest.xml