### PR TITLE
Add office-addin-mock for tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "office-addin-dev-certs": "^1.11.3",
         "office-addin-lint": "^2.2.5",
         "office-addin-manifest": "^1.12.3",
+        "office-addin-mock": "^3.0.3",
         "office-addin-prettier-config": "^1.2.0",
         "os-browserify": "^0.3.0",
         "process": "^0.11.10",
@@ -12623,6 +12624,99 @@
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true,
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/office-addin-mock": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/office-addin-mock/-/office-addin-mock-3.0.3.tgz",
+      "integrity": "sha512-EjIcO6W5Y3eqCkJm7KhpUyfmr9TVFUWyiIIZHZsWLUyd+KSg/FVDcKZPcslq61PWV4t9V8s8RApIv3bNg2NPqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "office-addin-manifest": "^2.0.3",
+        "office-addin-usage-data": "^2.0.3"
+      }
+    },
+    "node_modules/office-addin-mock/node_modules/commander": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/office-addin-mock/node_modules/fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/office-addin-mock/node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/office-addin-mock/node_modules/office-addin-manifest": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/office-addin-manifest/-/office-addin-manifest-2.0.3.tgz",
+      "integrity": "sha512-hqym0IOh2AP0y/T27hRKAQVC1mID900/jQ+ie6SW2UQ+tUtmc8CRhTOm33q9SY5SIVzDwXsNjNKzOdcjPUV6VQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/teams-manifest": "^0.1.3",
+        "adm-zip": "0.5.12",
+        "chalk": "^2.4.2",
+        "commander": "^13.0.0",
+        "fs-extra": "^7.0.1",
+        "node-fetch": "^2.6.1",
+        "office-addin-usage-data": "^2.0.3",
+        "uuid": "^8.3.2",
+        "xml2js": "^0.5.0"
+      },
+      "bin": {
+        "office-addin-manifest": "cli.js"
+      }
+    },
+    "node_modules/office-addin-mock/node_modules/office-addin-usage-data": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/office-addin-usage-data/-/office-addin-usage-data-2.0.3.tgz",
+      "integrity": "sha512-kKAqep+fBe6aFVFsaAQhDQ9UyaZRZnJNo+kWSfcasZGm4h1AS1cPrZvcqxaViD/MDAvGdsDCgKzgdzIcFjyzXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "applicationinsights": "^1.7.3",
+        "commander": "^13.0.0",
+        "readline-sync": "^1.4.9",
+        "uuid": "8.3.2"
+      },
+      "bin": {
+        "office-addin-usage-data": "cli.js"
+      }
+    },
+    "node_modules/office-addin-mock/node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 4.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "office-addin-dev-certs": "^1.11.3",
     "office-addin-lint": "^2.2.5",
     "office-addin-manifest": "^1.12.3",
+    "office-addin-mock": "^3.0.3",
     "office-addin-prettier-config": "^1.2.0",
     "os-browserify": "^0.3.0",
     "process": "^0.11.10",


### PR DESCRIPTION
We need to use `office-addin-mock` on #71, as preparation for it, add `office-addin-mock` as dev module.