### PR TITLE
Implement onAppointmentOrganizer for web fallback

### DIFF
--- a/src/web-fallback/app.js
+++ b/src/web-fallback/app.js
@@ -12,6 +12,11 @@ async function onNewMessageComposeCreated(event) {
 }
 window.onNewMessageComposeCreated = onNewMessageComposeCreated;
 
+async function onAppointmentOrganizer(event) {
+  event.completed();
+}
+window.onAppointmentOrganizer = onAppointmentOrganizer;
+
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 async function onOpenSettingDialog(event) {
   event.completed({ allowEvent: true });


### PR DESCRIPTION
Implement onAppointmentOrganizer for web fallback.

# Test

* Register manifest to Outlook
* Start command prompt
* Execute `npm run build:fallback`
  * `dist-fallback` folder is created
* Execute `cd tests\run-test-server`
* Exexute `run-test-server.bat`
* Replace `tests\run-test-server\web` with `dist-fallback`
* Open Outlook
* Open Schedule
* Send a new event
  * [x] Confirm that the event is sent with no confirmation