### PR TITLE
Drop jQuery

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@microsoft/office-js": "^1.1.110",
         "bootstrap": "^5.3.6",
         "core-js": "^3.42.0",
-        "jquery": "^3.7.1",
         "regenerator-runtime": "^0.14.1"
       },
       "devDependencies": {
@@ -9878,12 +9877,6 @@
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
-    },
-    "node_modules/jquery": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
-      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
-      "license": "MIT"
     },
     "node_modules/js-base64": {
       "version": "3.7.7",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "@microsoft/office-js": "^1.1.110",
     "bootstrap": "^5.3.6",
     "core-js": "^3.42.0",
-    "jquery": "^3.7.1",
     "regenerator-runtime": "^0.14.1"
   },
   "devDependencies": {

--- a/src/web/added-domains-reconfirmation.mjs
+++ b/src/web/added-domains-reconfirmation.mjs
@@ -63,22 +63,25 @@ export class AddedDomainsReconfirmation {
   }
 
   initUI(sendStatusToParent) {
-    const targetElement = $("#newly-added-domain-address-list");
+    const targetElement = document.getElementById("newly-added-domain-address-list");
     for (const address of this.newDomainAddresses) {
-      const itemElement = $(`<li></li>`).appendTo(targetElement);
-      const strongElement = $(`<strong></strong>`).appendTo(itemElement);
-      strongElement.text(address);
+      const itemElement = document.createElement("li");
+      const strongElement = document.createElement("strong");
+      strongElement.textContent = address;
+      itemElement.appendChild(strongElement);
+      targetElement.appendChild(itemElement);
     }
+
     window.onSendNewDomain = () => {
-      $("#newly-added-domain-address-dialog").prop("hidden", true);
+      document.getElementById("newly-added-domain-address-dialog").hidden = true;
       sendStatusToParent("ok");
     };
     window.onCancelNewDomain = () => {
-      $("#newly-added-domain-address-dialog").prop("hidden", true);
+      document.getElementById("newly-added-domain-address-dialog").hidden = true;
     };
   }
 
   show() {
-    $("#newly-added-domain-address-dialog").prop("hidden", false);
+    document.getElementById("newly-added-domain-address-dialog").hidden = false;
   }
 }

--- a/src/web/confirm.html
+++ b/src/web/confirm.html
@@ -13,7 +13,6 @@ Copyright (c) 2025 ClearCode Inc.
     <meta http-equiv="X-UA-Compatible" content="IE=Edge">
     <script src="lib/fluentui/web-components/web-components.min.js" type="module"></script>
     <script src="lib/office-js/office.js" type="text/javascript"></script>
-    <script src="lib/jquery/jquery.min.js" type="text/javascript"></script>
     <link href="dialog.css" rel="stylesheet">
     <link href="confirm.css" rel="stylesheet">
 </head>

--- a/src/web/confirm.js
+++ b/src/web/confirm.js
@@ -119,7 +119,7 @@ function appendMiscCheckboxes(items) {
 }
 
 function appendMiscWarningCheckboxes(items) {
-  const container = document.getElementById("#attachment-and-others");
+  const container = document.getElementById("attachment-and-others");
   for (const item of items) {
     appendCheckbox({
       container,

--- a/src/web/confirm.js
+++ b/src/web/confirm.js
@@ -48,10 +48,16 @@ function sendStatusToParent(status) {
 
 window.onCheckAllTrusted = () => {
   const checkTargetLength = document.querySelectorAll("fluent-checkbox.check-target").length;
-  const checkedTargetLength = document.querySelectorAll("fluent-checkbox.check-target.checked").length;
-  const trustedCheckboxes = document.querySelectorAll("#trusted-domains fluent-checkbox.check-target");
-  const toBeCheckedNumber = Array.from(trustedCheckboxes).filter(cb => !cb.classList.contains("checked")).length;
-  trustedCheckboxes.forEach(cb => cb.checked = true);
+  const checkedTargetLength = document.querySelectorAll(
+    "fluent-checkbox.check-target.checked"
+  ).length;
+  const trustedCheckboxes = document.querySelectorAll(
+    "#trusted-domains fluent-checkbox.check-target"
+  );
+  const toBeCheckedNumber = Array.from(trustedCheckboxes).filter(
+    (cb) => !cb.classList.contains("checked")
+  ).length;
+  trustedCheckboxes.forEach((cb) => (cb.checked = true));
   const hasUnchecked = checkTargetLength !== checkedTargetLength + toBeCheckedNumber;
   const sendButton = document.getElementById("send-button");
   sendButton.disabled = hasUnchecked;
@@ -71,7 +77,9 @@ window.onCancel = () => {
 
 window.checkboxChanged = (targetElement) => {
   const checkTargetLength = document.querySelectorAll("fluent-checkbox.check-target").length;
-  const checkedTargetLength = document.querySelectorAll("fluent-checkbox.check-target.checked").length;
+  const checkedTargetLength = document.querySelectorAll(
+    "fluent-checkbox.check-target.checked"
+  ).length;
   // If the target is currently checked, the target is unchecked after this function and vice versa.
   const adjustmentValue = targetElement.classList.contains("checked") ? -1 : 1;
   const hasUnchecked = checkTargetLength !== checkedTargetLength + adjustmentValue;
@@ -210,5 +218,6 @@ async function onMessageFromParent(arg) {
     data.itemType === Office.MailboxEnums.ItemType.Message
       ? l10n.get("newlyAddedDomainReconfirmation_messageBefore")
       : l10n.get("newlyAddedDomainReconfirmation_messageBeforeForAppointment");
-  document.getElementById("newly-added-domains-message-before").textContent = newlyAddedDomainsBeforeMessage;
+  document.getElementById("newly-added-domains-message-before").textContent =
+    newlyAddedDomainsBeforeMessage;
 }

--- a/src/web/confirm.js
+++ b/src/web/confirm.js
@@ -47,14 +47,14 @@ function sendStatusToParent(status) {
 }
 
 window.onCheckAllTrusted = () => {
-  const checkTargetLength = $("fluent-checkbox.check-target").length;
-  const checkedTargetLength = $("fluent-checkbox.check-target.checked").length;
-  const toBeCheckedNumber = $("#trusted-domains fluent-checkbox.check-target").not(
-    ".checked"
-  ).length;
-  $("#trusted-domains fluent-checkbox.check-target").prop("checked", true);
+  const checkTargetLength = document.querySelectorAll("fluent-checkbox.check-target").length;
+  const checkedTargetLength = document.querySelectorAll("fluent-checkbox.check-target.checked").length;
+  const trustedCheckboxes = document.querySelectorAll("#trusted-domains fluent-checkbox.check-target");
+  const toBeCheckedNumber = Array.from(trustedCheckboxes).filter(cb => !cb.classList.contains("checked")).length;
+  trustedCheckboxes.forEach(cb => cb.checked = true);
   const hasUnchecked = checkTargetLength !== checkedTargetLength + toBeCheckedNumber;
-  $("#send-button").prop("disabled", hasUnchecked);
+  const sendButton = document.getElementById("send-button");
+  sendButton.disabled = hasUnchecked;
 };
 
 window.onSend = () => {
@@ -70,26 +70,29 @@ window.onCancel = () => {
 };
 
 window.checkboxChanged = (targetElement) => {
-  const checkTargetLength = $("fluent-checkbox.check-target").length;
-  const checkedTargetLength = $("fluent-checkbox.check-target.checked").length;
+  const checkTargetLength = document.querySelectorAll("fluent-checkbox.check-target").length;
+  const checkedTargetLength = document.querySelectorAll("fluent-checkbox.check-target.checked").length;
   // If the target is currently checked, the target is unchecked after this function and vice versa.
-  const adjustmentValue = $(targetElement).hasClass("checked") ? -1 : 1;
+  const adjustmentValue = targetElement.classList.contains("checked") ? -1 : 1;
   const hasUnchecked = checkTargetLength !== checkedTargetLength + adjustmentValue;
-  $("#send-button").prop("disabled", hasUnchecked);
+  const sendButton = document.getElementById("send-button");
+  sendButton.disabled = hasUnchecked;
 };
 
 function appendRecipientCheckboxes(target, groupedRecipients) {
   for (const [key, recipients] of Object.entries(groupedRecipients)) {
     const idForGroup = generateTempId();
     const idForGroupTitle = generateTempId();
-    target.append(`
-      <div>
-        <h4 id="${idForGroupTitle}"></h4>
-        <fluent-stack id=${idForGroup} orientation="vertical" vertical-align="start"></fluent-stack>
-      </div>`);
+    target.insertAdjacentHTML(
+      "beforeend",
+      `<div>
+          <h4 id="${idForGroupTitle}"></h4>
+          <fluent-stack id="${idForGroup}" orientation="vertical" vertical-align="start"></fluent-stack>
+      </div>`
+    );
     //In order to escape special chars, adding values with the text function.
-    $(`#${idForGroupTitle}`).text(key);
-    const container = $(`#${idForGroup}`);
+    document.getElementById(idForGroupTitle).textContent = key;
+    const container = document.getElementById(idForGroup);
     for (const recipient of recipients) {
       const label = `${recipient.type}: ${recipient.address}`;
       appendCheckbox({ container, label });
@@ -98,7 +101,7 @@ function appendRecipientCheckboxes(target, groupedRecipients) {
 }
 
 function appendMiscCheckboxes(items) {
-  const container = $("#attachment-and-others");
+  const container = document.getElementById("attachment-and-others");
   for (const item of items) {
     appendCheckbox({
       container,
@@ -108,7 +111,7 @@ function appendMiscCheckboxes(items) {
 }
 
 function appendMiscWarningCheckboxes(items) {
-  const container = $("#attachment-and-others");
+  const container = document.getElementById("#attachment-and-others");
   for (const item of items) {
     appendCheckbox({
       container,
@@ -126,13 +129,14 @@ function appendCheckbox({ container, id, label, warning }) {
   if (warning) {
     extraClasses.add("warning");
   }
-  container.append(
-    `<fluent-checkbox id="${id}" class="check-target ${[...extraClasses].join(
-      " "
-    )}" onchange="checkboxChanged(this)"></fluent-checkbox>`
-  );
-  //In order to escape special chars, adding values with the text function.
-  $(`#${id}`).text(label);
+  const checkbox = document.createElement("fluent-checkbox");
+  checkbox.id = id;
+  checkbox.className = "check-target " + [...extraClasses].join(" ");
+  checkbox.setAttribute("onchange", "checkboxChanged(this)");
+
+  //In order to escape special chars, use textContent.
+  checkbox.textContent = label;
+  container.appendChild(checkbox);
 }
 
 async function onMessageFromParent(arg) {
@@ -171,12 +175,12 @@ async function onMessageFromParent(arg) {
   await Promise.all([l10n.ready, safeBccConfirmation.loaded, attachmentsConfirmation.loaded]);
 
   if (data.classified.trusted.length == 0) {
-    $("#check-all-trusted").prop("disabled", true);
+    document.getElementById("check-all-trusted").disabled = true;
   }
   const groupedByTypeTrusteds = Object.groupBy(data.classified.trusted, (item) => item.domain);
-  appendRecipientCheckboxes($("#trusted-domains"), groupedByTypeTrusteds);
+  appendRecipientCheckboxes(document.getElementById("trusted-domains"), groupedByTypeTrusteds);
   const groupedByTypeUntrusted = Object.groupBy(data.classified.untrusted, (item) => item.domain);
-  appendRecipientCheckboxes($("#untrusted-domains"), groupedByTypeUntrusted);
+  appendRecipientCheckboxes(document.getElementById("untrusted-domains"), groupedByTypeUntrusted);
 
   safeBccConfirmation.init(data);
   appendMiscWarningCheckboxes(safeBccConfirmation.warningConfirmationItems);
@@ -206,5 +210,5 @@ async function onMessageFromParent(arg) {
     data.itemType === Office.MailboxEnums.ItemType.Message
       ? l10n.get("newlyAddedDomainReconfirmation_messageBefore")
       : l10n.get("newlyAddedDomainReconfirmation_messageBeforeForAppointment");
-  $("#newly-added-domains-message-before").text(newlyAddedDomainsBeforeMessage);
+  document.getElementById("newly-added-domains-message-before").textContent = newlyAddedDomainsBeforeMessage;
 }

--- a/src/web/count-down.html
+++ b/src/web/count-down.html
@@ -13,7 +13,6 @@ Copyright (c) 2025 ClearCode Inc.
     <meta http-equiv="X-UA-Compatible" content="IE=Edge">
     <script src="lib/fluentui/web-components/web-components.min.js" type="module"></script>
     <script src="lib/office-js/office.js" type="text/javascript"></script>
-    <script src="lib/jquery/jquery.min.js" type="text/javascript"></script>
     <link href="dialog.css" rel="stylesheet">
     <link href="count-down.css" rel="stylesheet">
 </head>

--- a/src/web/count-down.js
+++ b/src/web/count-down.js
@@ -49,11 +49,11 @@ async function onMessageFromParent(arg) {
 
   if (!data.config.common.CountAllowSkip) {
     console.log("cannot skip");
-    $("#send-button").hide();
+    document.getElementById("send-button").style.display = "none";
   }
 
-  $("#count").text(data.config.common.CountSeconds);
-  $("#message").show();
+  document.getElementById("count").textContent = data.config.common.CountSeconds;
+  document.getElementById("message").style.display = "inline";
 
   Dialog.resizeToContent();
 
@@ -61,7 +61,7 @@ async function onMessageFromParent(arg) {
   const timer = window.setInterval(() => {
     const rest = Math.ceil(data.config.common.CountSeconds - (Date.now() - start) / 1000);
     console.log("rest: ", rest);
-    $("#count").text(rest);
+    document.getElementById("count").textContent = rest;
     if (rest > 0) {
       return;
     }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -78,14 +78,6 @@ module.exports = async (env, options) => {
             to: "lib/office-js/LICENSE.md",
           },
           {
-            from: "node_modules/jquery/dist/jquery.min.js",
-            to: "lib/jquery/jquery.min.js",
-          },
-          {
-            from: "node_modules/jquery/LICENSE.txt",
-            to: "lib/jquery/LICENSE.txt",
-          },
-          {
             from: "node_modules/@fluentui/web-components/dist/web-components.min.js",
             to: "lib/fluentui/web-components/web-components.min.js",
           },


### PR DESCRIPTION
We don't need to use jQuery.

This patch drops jQuery and implement with Vanilla JS.


## Test

* Do the following pre-release "General Setting" tests except "Delay Delivery" and "Schedule confirmation".
  * This patch affects to the confirmation dialog, the count down dialog and thew newly added domain dialog, so we can skip  tests of  "Delay Delivery" and "Schedule confirmation"

https://gitlab.clear-code.com/thunderbird-support/outlook-office-addin-enterprise/-/blob/main/doc/verify/sources/Windows/PreReleaseTests.md?ref_type=heads#%E4%B8%80%E8%88%AC%E8%A8%AD%E5%AE%9A