### PR TITLE
unify checkbox items by label

### DIFF
--- a/src/web/confirm.js
+++ b/src/web/confirm.js
@@ -101,31 +101,48 @@ function appendRecipientCheckboxes(target, groupedRecipients) {
     //In order to escape special chars, adding values with the text function.
     document.getElementById(idForGroupTitle).textContent = key;
     const container = document.getElementById(idForGroup);
+    const createdLabels = new Set();
     for (const recipient of recipients) {
       const label = `${recipient.type}: ${recipient.address}`;
+      if (createdLabels.has(label)){
+        continue;
+      }
       appendCheckbox({ container, label });
+      createdLabels.add(label);
     }
   }
 }
 
 function appendMiscCheckboxes(items) {
   const container = document.getElementById("attachment-and-others");
+  const createdLabels = new Set();
   for (const item of items) {
+    const label = item.label || item;
+    if (createdLabels.has(label)){
+      continue;
+    }
     appendCheckbox({
       container,
-      label: item.label || item,
+      label,
     });
+    createdLabels.add(label);
   }
 }
 
 function appendMiscWarningCheckboxes(items) {
   const container = document.getElementById("attachment-and-others");
+  const createdLabels = new Set();
   for (const item of items) {
+    const label = item.label || item;
+    if (createdLabels.has(label)){
+      continue;
+    }
     appendCheckbox({
       container,
-      label: item.label || item,
+      label,
       warning: true,
     });
+    createdLabels.add(label);
   }
 }
 

--- a/src/web/confirm.js
+++ b/src/web/confirm.js
@@ -104,7 +104,7 @@ function appendRecipientCheckboxes(target, groupedRecipients) {
     const createdLabels = new Set();
     for (const recipient of recipients) {
       const label = `${recipient.type}: ${recipient.address}`;
-      if (createdLabels.has(label)){
+      if (createdLabels.has(label)) {
         continue;
       }
       appendCheckbox({ container, label });
@@ -118,7 +118,7 @@ function appendMiscCheckboxes(items) {
   const createdLabels = new Set();
   for (const item of items) {
     const label = item.label || item;
-    if (createdLabels.has(label)){
+    if (createdLabels.has(label)) {
       continue;
     }
     appendCheckbox({
@@ -134,7 +134,7 @@ function appendMiscWarningCheckboxes(items) {
   const createdLabels = new Set();
   for (const item of items) {
     const label = item.label || item;
-    if (createdLabels.has(label)){
+    if (createdLabels.has(label)) {
       continue;
     }
     appendCheckbox({


### PR DESCRIPTION
Currently, if we specify the same addresses to To, Cc or Bcc, checkboxes for those addresses are displayed duplicately on the confirmation dialog.

![image](https://github.com/user-attachments/assets/b3d6bf6c-28c3-42b8-8b60-11da2d39b832)

We use the `Set` class in `recipient-classifier.mjs`, but they are different object from each other, so they are not unified.

https://github.com/FlexConfirmMail/Outlook-Office-Addin/blob/main/src/web/recipient-classifier.mjs#L130

This patch resolves that problem, and unifies checkbox items by label.

![image](https://github.com/user-attachments/assets/a389a225-5ddb-4cc3-ada2-e3e5dcebc162)
