### PR TITLE
openDialog: wait until a previous dialog closes

### DIFF
--- a/src/web/app.js
+++ b/src/web/app.js
@@ -31,7 +31,7 @@ Office.onReady(() => {
 });
 
 function sleepAsync(ms) {
-  return new Promise(resolve => setTimeout(resolve, ms));
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 function getBccAsync() {
@@ -294,7 +294,7 @@ async function openDialog({ url, data, asyncContext, promptBeforeOpen, ...params
         console.log(
           "could not open dialog before the previous dialog is not closed completely, so we need to retry it manually."
         );
-        await sleepAsync(2000);
+        await sleepAsync(1000);
         return openDialog({ url, data, asyncContext, ...params });
 
       case 12011:


### PR DESCRIPTION
For https://github.com/FlexConfirmMail/Outlook-Office-Addin/issues/82

Add sleep when the previous dialog does not close.

In my environment, on classic Outlook, `openDialog` fails to open the count down dialog at first time because a previous confirmation dialog. On that case, `openDialog` retries to open the count down dialog but did not sleep before the retry. 
As a result, `openDialog` could not open the count down dialog multiple times and could not proceed with the process.

## Test

* [x] Confirm that the count down dialog is displayed on Outlook on the web
* [x] Confirm that the count down dialog is displayed on classic Outlook