### PR TITLE
Remove Office.initialize

### DIFF
--- a/src/web/app.js
+++ b/src/web/app.js
@@ -19,10 +19,6 @@ const CONFIRM_ATTACHMENT_TYPES = new Set([
 ]);
 let locale;
 
-Office.initialize = (reason) => {
-  console.debug("Office.initialize reasion = ", reason);
-};
-
 Office.onReady(() => {
   const language = Office.context.displayLanguage;
   document.documentElement.setAttribute("lang", language);

--- a/src/web/confirm.js
+++ b/src/web/confirm.js
@@ -16,9 +16,6 @@ let safeBccConfirmation;
 let attachmentsConfirmation;
 const addedDomainsReconfirmation = new AddedDomainsReconfirmation();
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-Office.initialize = (_reason) => {};
-
 Office.onReady(() => {
   const language = Office.context.displayLanguage;
   l10n = L10n.get(language);

--- a/src/web/count-down.js
+++ b/src/web/count-down.js
@@ -10,9 +10,6 @@ import * as Dialog from "./dialog.mjs";
 
 let l10n;
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-Office.initialize = (_reason) => {};
-
 Office.onReady(() => {
   const language = Office.context.displayLanguage;
   l10n = L10n.get(language);


### PR DESCRIPTION
lint recommends to not use Office.initialize.

```
22:1  warning  Office.onReady() is preferred over Office.initialize  office-addins/no-office-initialize
```

## Test

* [x] Confirm that the confirmation dialog and the count down dialog are displayed on Outlook on the web
* [x] Confirm that the confirmation dialog and the count down dialog are displayed on classic Outlook