### PR TITLE
Fix newly added domain bug on classic Outlook appointment

### DIFF
--- a/src/web/app.js
+++ b/src/web/app.js
@@ -64,6 +64,20 @@ function getCcAsync() {
   });
 }
 
+function getItemIdAsync() {
+  return new Promise((resolve, reject) => {
+    try {
+      Office.context.mailbox.item.getItemIdAsync((asyncResult) => {
+        const id = asyncResult.value;
+        resolve(id);
+      });
+    } catch (error) {
+      console.log(`Error while getting itemId: ${error}`);
+      reject(error);
+    }
+  });
+}
+
 function getRequiredAttendeeAsync() {
   return new Promise((resolve, reject) => {
     try {
@@ -589,11 +603,15 @@ async function onNewMessageComposeCreated(event) {
 window.onNewMessageComposeCreated = onNewMessageComposeCreated;
 
 async function onAppointmentOrganizer(event) {
-  const [requiredAttendees, optionalAttendees] = await Promise.all([
+  const [id, requiredAttendees, optionalAttendees] = await Promise.all([
+    getItemIdAsync(),
     getRequiredAttendeeAsync(),
     getOptionalAttendeeAsync(),
   ]);
-  if (requiredAttendees.length > 0 || optionalAttendees.length > 0) {
+  // The id is defined if this is an existing appointment.
+  // We need this check for classic Outlook because classic Outlook has
+  // a current user in requiredAttendees even if this is a new appointment.
+  if (id && (requiredAttendees.length > 0 || optionalAttendees.length > 0)) {    
     const originalAttendees = {
       requiredAttendees,
       optionalAttendees,

--- a/src/web/app.js
+++ b/src/web/app.js
@@ -611,7 +611,7 @@ async function onAppointmentOrganizer(event) {
   // The id is defined if this is an existing appointment.
   // We need this check for classic Outlook because classic Outlook has
   // a current user in requiredAttendees even if this is a new appointment.
-  if (id && (requiredAttendees.length > 0 || optionalAttendees.length > 0)) {    
+  if (id && (requiredAttendees.length > 0 || optionalAttendees.length > 0)) {
     const originalAttendees = {
       requiredAttendees,
       optionalAttendees,


### PR DESCRIPTION
For https://github.com/FlexConfirmMail/Outlook-Office-Addin/issues/87

Note: this patch works only after https://github.com/FlexConfirmMail/Outlook-Office-Addin/pull/83 is merged.

RequiredAttendees has a current user even when sending a new appointment on classic Outlook. As a result, the current user is added to the session data for checking newly added domains even it is a new appointment. That causes a false warning.

This patch adds a check whether an appointment is a new appointment or not.

## Test 

I have tested this procedure after locally applying https://github.com/FlexConfirmMail/Outlook-Office-Addin/pull/83 .


* Classic Outlook
  * Enable appointment confirmation on the setting dialog.
  * Send a new appointment to your self.
    * [x] Confirm that a confirmation dialog is displayed
    * [x] Confirm that a warning for a newly added domain (`test@example.com`) is **not** displayed
  * Edit the sent appointment
  * Add a new domain attendee like `test@example.com`
  * Send the edited appointment
    * [x] Confirm that a confirmation dialog is displayed
  * Click the "Send" button on the confirmation dialog
    * [x] Confirm that a warning for a newly added domain (`test@example.com`) is displayed
* Outlook on the web
  * Enable appointment confirmation on the setting dialog.
  * Send a new appointment to your self.
    * [x] Confirm that a confirmation dialog is displayed
    * [x] Confirm that a warning for a newly added domain (`test@example.com`) is **not** displayed
  * Edit the sent appointment
  * Add a new domain attendee like `test@example.com`
  * Send the edited appointment
    * [x] Confirm that a confirmation dialog is displayed
  * Click the "Send" button on the confirmation dialog
    * [x] Confirm that a warning for a newly added domain (`test@example.com`) is displayed