### PR TITLE
Fix a bug that newly added domain warning does not work on new Outloo…

### DIFF
--- a/src/web/app.js
+++ b/src/web/app.js
@@ -610,8 +610,8 @@ async function onAppointmentOrganizer(event) {
   ]);
 
   if (Office.context.platform == Office.PlatformType.PC) {
-    // On classic Outlook, requiredAttendees has a current user even if 
-    // this is a new appointment, in that case, subsequent processing 
+    // On classic Outlook, requiredAttendees has a current user even if
+    // this is a new appointment, in that case, subsequent processing
     // erroneously determines that there are existing attendees.
     // This function has nothing to do if this is a new appointment
     // because there is no existing attendees. So return if this is a

--- a/src/web/app.js
+++ b/src/web/app.js
@@ -604,15 +604,27 @@ async function onNewMessageComposeCreated(event) {
 window.onNewMessageComposeCreated = onNewMessageComposeCreated;
 
 async function onAppointmentOrganizer(event) {
-  const [id, requiredAttendees, optionalAttendees] = await Promise.all([
-    getItemIdAsync(),
+  const [requiredAttendees, optionalAttendees] = await Promise.all([
     getRequiredAttendeeAsync(),
     getOptionalAttendeeAsync(),
   ]);
-  // The id is defined if this is an existing appointment.
-  // We need this check for classic Outlook because classic Outlook has
-  // a current user in requiredAttendees even if this is a new appointment.
-  if (id && (requiredAttendees.length > 0 || optionalAttendees.length > 0)) {
+
+  if (Office.context.platform == Office.PlatformType.PC) {
+    // On classic Outlook, requiredAttendees has a current user even if 
+    // this is a new appointment, in that case, subsequent processing 
+    // erroneously determines that there are existing attendees.
+    // This function has nothing to do if this is a new appointment
+    // because there is no existing attendees. So return if this is a
+    // new appointment.
+    const id = await getItemIdAsync();
+    if (!id) {
+      // On classic Outlook, if the id is not defined, this is a new appointment.
+      event.completed();
+      return;
+    }
+  }
+
+  if (requiredAttendees.length > 0 || optionalAttendees.length > 0) {
     const originalAttendees = {
       requiredAttendees,
       optionalAttendees,


### PR DESCRIPTION
For https://github.com/FlexConfirmMail/Outlook-Office-Addin/issues/91

On new Outlook, the id is undefined even when editing an existing appointment.
By the above reason, the session data was not set, and the warning for newly added domains was not work on new Outlook.

## Test

* Classic Outlook
  * Enable appointment confirmation on the setting dialog.
  * Send a new appointment to your self.
    * [x] Confirm that a confirmation dialog is displayed
    * [x] Confirm that a warning for a newly added domain (`test@example.com`) is **not** displayed
  * Edit the sent appointment
  * Add a new domain attendee like `test@example.com`
  * Send the edited appointment
    * [x] Confirm that a confirmation dialog is displayed
  * Click the "Send" button on the confirmation dialog
    * [x] Confirm that a warning for a newly added domain (`test@example.com`) is displayed
* New Outlook
  * Enable appointment confirmation on the setting dialog.
  * Send a new appointment to your self.
    * [x] Confirm that a confirmation dialog is displayed
    * [x] Confirm that a warning for a newly added domain (`test@example.com`) is **not** displayed
  * Edit the sent appointment
  * Add a new domain attendee like `test@example.com`
  * Send the edited appointment
    * [x] Confirm that a confirmation dialog is displayed
  * Click the "Send" button on the confirmation dialog
    * [x] Confirm that a warning for a newly added domain (`test@example.com`) is displayed
* Outlook on the web
  * Enable appointment confirmation on the setting dialog.
  * Send a new appointment to your self.
    * [x] Confirm that a confirmation dialog is displayed
    * [x] Confirm that a warning for a newly added domain (`test@example.com`) is **not** displayed
  * Edit the sent appointment
  * Add a new domain attendee like `test@example.com`
  * Send the edited appointment
    * [x] Confirm that a confirmation dialog is displayed
  * Click the "Send" button on the confirmation dialog
    * [x] Confirm that a warning for a newly added domain (`test@example.com`) is displayed