### PR TITLE
Use inframe dialog

### DIFF
--- a/src/web/app.js
+++ b/src/web/app.js
@@ -309,7 +309,7 @@ async function openDialog({ url, data, asyncContext, promptBeforeOpen, ...params
         return openDialog({ url, data, asyncContext, ...params });
 
       case 12011:
-        // Maybe we never reach this case because we specify displayInIframe = true at the 
+        // Maybe we never reach this case because we specify displayInIframe = true at the
         // first time and then displayDialogAsync does not open a new popup dialog.
         console.log("failed due to the browser's popup blocker.");
         if (promptBeforeOpen) {

--- a/src/web/app.js
+++ b/src/web/app.js
@@ -289,6 +289,7 @@ async function openDialog({ url, data, asyncContext, promptBeforeOpen, ...params
       url,
       {
         asyncContext,
+        displayInIframe: !promptBeforeOpen,
         promptBeforeOpen: promptBeforeOpen || false,
         ...params,
       },
@@ -308,6 +309,8 @@ async function openDialog({ url, data, asyncContext, promptBeforeOpen, ...params
         return openDialog({ url, data, asyncContext, ...params });
 
       case 12011:
+        // Maybe we never reach this case because we specify displayInIframe = true at the 
+        // first time and then displayDialogAsync does not open a new popup dialog.
         console.log("failed due to the browser's popup blocker.");
         if (promptBeforeOpen) {
           break;
@@ -435,7 +438,7 @@ async function tryConfirm(data, asyncContext) {
     data,
     asyncContext,
     height: Math.min(60, charsToPercentage(50, screen.availHeight)),
-    width: Math.min(80, charsToPercentage(45, screen.availWidth)),
+    width: Math.min(80, charsToPercentage(60, screen.availWidth)),
   });
   console.debug("status: ", status);
 
@@ -648,7 +651,7 @@ async function onOpenSettingDialog(event) {
     data,
     asyncContext,
     height: Math.min(80, charsToPercentage(70, screen.availHeight)),
-    width: Math.min(80, charsToPercentage(70, screen.availWidth)),
+    width: Math.min(80, charsToPercentage(80, screen.availWidth)),
   });
   console.debug(`onOpensettingDialog: ${status}`);
   updatedAsyncContext.completed({ allowEvent: true });

--- a/src/web/confirm.js
+++ b/src/web/confirm.js
@@ -17,6 +17,10 @@ let attachmentsConfirmation;
 const addedDomainsReconfirmation = new AddedDomainsReconfirmation();
 
 Office.onReady(() => {
+  if (window !== window.parent) {
+    // Inframe mode
+    document.documentElement.classList.add('in-frame');
+  }
   const language = Office.context.displayLanguage;
   l10n = L10n.get(language);
   l10n.ready.then(() => l10n.translateAll());

--- a/src/web/confirm.js
+++ b/src/web/confirm.js
@@ -19,7 +19,7 @@ const addedDomainsReconfirmation = new AddedDomainsReconfirmation();
 Office.onReady(() => {
   if (window !== window.parent) {
     // Inframe mode
-    document.documentElement.classList.add('in-frame');
+    document.documentElement.classList.add("in-frame");
   }
   const language = Office.context.displayLanguage;
   l10n = L10n.get(language);

--- a/src/web/count-down.js
+++ b/src/web/count-down.js
@@ -13,7 +13,7 @@ let l10n;
 Office.onReady(() => {
   if (window !== window.parent) {
     // Inframe mode
-    document.documentElement.classList.add('in-frame');
+    document.documentElement.classList.add("in-frame");
   }
   const language = Office.context.displayLanguage;
   l10n = L10n.get(language);

--- a/src/web/count-down.js
+++ b/src/web/count-down.js
@@ -11,6 +11,10 @@ import * as Dialog from "./dialog.mjs";
 let l10n;
 
 Office.onReady(() => {
+  if (window !== window.parent) {
+    // Inframe mode
+    document.documentElement.classList.add('in-frame');
+  }
   const language = Office.context.displayLanguage;
   l10n = L10n.get(language);
   l10n.ready.then(() => l10n.translateAll());

--- a/src/web/dialog.css
+++ b/src/web/dialog.css
@@ -15,6 +15,10 @@ fluent-divider {
   text-align: right;
 }
 
+.in-frame .button-container {
+  padding-bottom: 0px;
+}
+
 #cancel-button {
   margin-left: 10px;
 }
@@ -28,12 +32,23 @@ fluent-divider {
   background: var(--neutral-fill-secondary-rest);
 }
 
+.in-frame .dialog-content {
+  padding-left: 0px;
+  padding-right: 0px;
+  background: var(--neutralPrimarySurface);;
+}
+
 .dialog-footer {
   position: sticky;
   bottom: 0;
   padding: 10px;
   text-align: center;
   background: var(--neutral-fill-secondary-rest);
+}
+
+.in-frame .dialog-footer {
+  padding: 5px;
+  background: var(--neutralPrimarySurface);
 }
 
 .dialog-body {

--- a/src/web/setting.css
+++ b/src/web/setting.css
@@ -61,11 +61,4 @@ fluent-number-field {
   margin-left: 10px;
 }
 
-/* fluent-tab:hover {
-  background-color: #F5F5F5;
-}
-
-fluent-tab:active {
-  background-color: #FAFAFA;
-} */
 

--- a/src/web/setting.js
+++ b/src/web/setting.js
@@ -16,7 +16,7 @@ let effectiveConfig;
 Office.onReady(() => {
   if (window !== window.parent) {
     // Inframe mode
-    document.documentElement.classList.add('in-frame');
+    document.documentElement.classList.add("in-frame");
   }
   Office.context.ui.addHandlerAsync(
     Office.EventType.DialogParentMessageReceived,

--- a/src/web/setting.js
+++ b/src/web/setting.js
@@ -14,6 +14,10 @@ let userConfig;
 let effectiveConfig;
 
 Office.onReady(() => {
+  if (window !== window.parent) {
+    // Inframe mode
+    document.documentElement.classList.add('in-frame');
+  }
   Office.context.ui.addHandlerAsync(
     Office.EventType.DialogParentMessageReceived,
     onMessageFromParent


### PR DESCRIPTION
https://github.com/FlexConfirmMail/Outlook-Office-Addin/issues/94

ダイアログの表示時に、inframeダイアログを使用するように修正。
これにより、ダイアログがポップアップではなくなるので、新しいウィンドウからメールを送信する場合もダイアログが表示される。

従来のダイアログとの差異は以下の通り。

* Outlook on the webと新しいOutlookに影響する
  * クラシックOutlookではinframeダイアログが使えないので従来通り
  * 新しいOutlookでは従来のダイアログでも良いのだが、Outlook on the webと新しいOutlookをOffice APIで見分けられないのでこのような仕様とした。
    * 先に従来のダイアログ（ポップアップ形式）で開いて、失敗したらInframeで開く、とすると新しいOutlookの時も従来のダイアログを使うことは可能なのだが、そうするとOutlook on the webの時に、一度ダイアログの表示に失敗をする都合上、ダイアログの表示までがかなり遅かったので、この方針は取らなかった。
* 画面内にiframeとして表示され、自由に移動できない
  * 画面が極端に小さい場合、表示が崩れることがあるが、現状では仕様としたい
* 背景が白になる

新しい確認ダイアログ:

<img width="1345" height="913" alt="image" src="https://github.com/user-attachments/assets/e20548d2-fc10-4554-8464-861e1ebf2bb5" />

新しい設定ダイアログ:

<img width="1345" height="913" alt="image" src="https://github.com/user-attachments/assets/46d5a91e-56ba-416c-838d-94c02e6f829a" />

参考: 

従来の確認ダイアログ:

<img width="712" height="587" alt="image" src="https://github.com/user-attachments/assets/2d88c07b-533c-48c8-9b5b-424cd3b81b67" />

新しい設定ダイアログ:

<img width="1115" height="929" alt="image" src="https://github.com/user-attachments/assets/e12ab335-f574-4137-838c-6af743f196ac" />

## テスト

* Outlook on the web
  * 新規メールを作成する
  * 上部のリボンから、メッセージ->アドイン->FlexConfirmMailを選択する
    * [x] 新しい設定ダイアログが表示されること
  * キャンセルボタンで閉じる
  * 新規メールを作成し、自分自身を宛先とし、送信ボタンをクリックする
    * [x] 新しい確認ダイアログが表示されること
  * 確認ダイアログで、すべての送信先にチェックを入れる
    * [x] 送信ボタンが有効になること
  * 送信ボタンをクリックする
    * [x] 新しいカウントダウンダイアログが表示されること
  * キャンセルボタンで送信をキャンセルする
  * 新規メールを作成し、右上の「新しいウィンドウで開く」ボタンを押し、メールの編集用の新しいウィンドウを開く
  * 自分自身を宛先とし、送信ボタンをクリックする
    * [x] 新しい確認ダイアログが表示されること
  * 確認ダイアログで、すべての送信先にチェックを入れる
    * [x] 送信ボタンが有効になること
  * 送信ボタンをクリックする
    * [x] 新しいカウントダウンダイアログが表示されること
  * カウントダウンの完了まで待つ
    * [x] メールが送信されること
* 新しいOutlook
  * 新規メールを作成する
  * 上部のリボンから、メッセージ->アドイン->FlexConfirmMailを選択する
    * [x] 新しい設定ダイアログが表示されること
  * キャンセルボタンで閉じる
  * 新規メールを作成し、自分自身を宛先とし、送信ボタンをクリックする
    * [x] 新しい確認ダイアログが表示されること
  * 確認ダイアログで、すべての送信先にチェックを入れる
    * [x] 送信ボタンが有効になること
  * 送信ボタンをクリックする
    * [x] 新しい形式のカウントダウンダイアログが表示されること
  * キャンセルボタンで送信をキャンセルする
  * 新規メールを作成し、右上の「新しいウィンドウで開く」ボタンを押し、メールの編集用の新しいウィンドウを開く
  * 自分自身を宛先とし、送信ボタンをクリックする
    * [x] 新しい確認ダイアログが表示されること
  * 確認ダイアログで、すべての送信先にチェックを入れる
    * [x] 送信ボタンが有効になること
  * 送信ボタンをクリックする
    * [x] 新しいカウントダウンダイアログが表示されること
  * カウントダウンの完了まで待つ
    * [x] メールが送信されること
* クラシックOutlook
  * 新規メールを作成する
  * 上部のリボンから、メッセージ->アドイン->FlexConfirmMailを選択する
    * [x] **従来の**設定ダイアログが表示されること
  * キャンセルボタンで閉じる
  * 新規メールを作成し、自分自身を宛先とし、送信ボタンをクリックする
    * [x] **従来の**確認ダイアログが表示されること
  * 確認ダイアログで、すべての送信先にチェックを入れる
    * [x] 送信ボタンが有効になること
  * 送信ボタンをクリックする
    * [x] **従来の**カウントダウンダイアログが表示されること
  * キャンセルボタンで送信をキャンセルする
  * 新規メールを作成し、右上の「新しいウィンドウで開く」ボタンを押し、メールの編集用の新しいウィンドウを開く
  * 自分自身を宛先とし、送信ボタンをクリックする
    * [x] **従来の**確認ダイアログが表示されること
  * 確認ダイアログで、すべての送信先にチェックを入れる
    * [x] 送信ボタンが有効になること
  * 送信ボタンをクリックする
    * [x] **従来の**カウントダウンダイアログが表示されること
  * カウントダウンの完了まで待つ
    * [x] メールが送信されること