### PR TITLE
Support multiple reconfirmation

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -19,8 +19,8 @@
   "newlyAddedDomainReconfirmation_messageBefore": "There are recipients with domains not included in the recipients of the original message.",
   "newlyAddedDomainReconfirmation_messageBeforeForAppointment": "There are attendees with domains not included in the attendees of the original appointment.",
   "newlyAddedDomainReconfirmation_messageAfter": "Do you really want to send this message?",
-  "newlyAddedDomainReconfirmation_sendButtonLabel": "Send",
-  "newlyAddedDomainReconfirmation_cancelButtonLabel": "Cancel",
+  "Reconfirmation_okButtonLabel": "OK",
+  "Reconfirmation_cancelButtonLabel": "Cancel",
 
   "countDown_messageBefore": "",
   "countDown_messageAfter": "seconds to send",

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -19,8 +19,8 @@
   "newlyAddedDomainReconfirmation_messageBefore": "返信元のメールの宛先に含まれていなかったドメインの以下の宛先が追加されています。",
   "newlyAddedDomainReconfirmation_messageBeforeForAppointment": "変更前の予定の出席者に含まれていなかったドメインの以下の出席者が追加されています。",
   "newlyAddedDomainReconfirmation_messageAfter": "送信してよろしいですか？",
-  "newlyAddedDomainReconfirmation_sendButtonLabel": "送信",
-  "newlyAddedDomainReconfirmation_cancelButtonLabel": "キャンセル",
+  "Reconfirmation_okButtonLabel": "OK",
+  "Reconfirmation_cancelButtonLabel": "キャンセル",
 
   "countDown_messageBefore": "",
   "countDown_messageAfter": "秒後に送信します",
@@ -49,6 +49,7 @@
   "setting_configAppointmentConfirmationEnabled": "予定表から予定を送信する場合にも確認する",
   "setting_configSafeBccEnabled": "To/CCに一定数以上のドメインが含まれている場合に警告する",
   "setting_configSafeBccThreshold": "警告対象となるドメインの数:",
+  "setting_configSafeBccReconfirmationThreshold": "再警告対象となるドメインの数:",
   "setting_configSafeNewDomainsEnabled": "返信の宛先に今まで含まれていなかったドメインのアドレスが追加された場合に警告する",
   "setting_configTrustedDomains": "社内ドメイン・アドレス",
   "setting_configUnsafeDomains": "注意が必要なドメイン・アドレス",

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -19,8 +19,8 @@
   "newlyAddedDomainReconfirmation_messageBefore": "收件人添加了以下原邮件收件人中未包含的域名地址。",
   "newlyAddedDomainReconfirmation_messageBeforeForAppointment": "There are attendees with domains not included in the attendees of the original appointment.",
   "newlyAddedDomainReconfirmation_messageAfter": "请确认是否要发送此邮件？",
-  "newlyAddedDomainReconfirmation_sendButtonLabel": "发送",
-  "newlyAddedDomainReconfirmation_cancelButtonLabel": "取消",
+  "Reconfirmation_okButtonLabel": "OK",
+  "Reconfirmation_cancelButtonLabel": "取消",
 
   "countDown_messageBefore": "",
   "countDown_messageAfter": "秒后发送",

--- a/src/web/confirm.css
+++ b/src/web/confirm.css
@@ -38,6 +38,7 @@ Copyright (c) 2025 ClearCode Inc.
   text-align: center;
 } */
 
+
 fluent-dialog::part(control) {
   color: white;
   background-color: red;
@@ -47,31 +48,59 @@ fluent-dialog::part(control) {
   --dialog-height: fit-content;
 }
 
-fluent-dialog::part(control) .newly-added-domain-content {
+fluent-dialog::part(control) .reconfirmation-content {
   background-color: white;
   background: var(--bg-color) !important;
 }
 
-fluent-dialog .newly-added-domain-content {
+fluent-dialog .reconfirmation-content {
   color: black;
   padding: 2em;
   text-align: left;
 }
 
-fluent-dialog .newly-added-domain-content strong {
+fluent-dialog .reconfirmation-content strong {
   font-size: large;
   font-weight: bold;
 }
 
-#newly-added-domain-address-list {
+.reconfirmation-list {
   margin: 1em 0;
 }
 
-#cancel-new-domain-button {
+#cancel-reconfirmation-button {
   margin-left: 10px;
 }
 
 .new-domain-button-container {
+  margin-top: 20px;
+}
+
+fluent-dialog::part(control) .reconfirmation-content {
+  background-color: white;
+  background: var(--bg-color) !important;
+}
+
+fluent-dialog .reconfirmation-content {
+  color: black;
+  padding: 2em;
+  text-align: left;
+}
+
+fluent-dialog .reconfirmation-content strong {
+  font-size: large;
+  font-weight: bold;
+}
+
+#reconfirmation-list {
+  margin: 1em 0;
+}
+
+#cancel-reconfirmation-button {
+  margin-left: 10px;
+}
+
+.reconfirmation-container {
   margin-top: 20px;
 }
 

--- a/src/web/confirm.html
+++ b/src/web/confirm.html
@@ -52,19 +52,16 @@ Copyright (c) 2025 ClearCode Inc.
                 data-l10n-text-content="confirmation_cancelButtonLabel"></fluent-button>
         </div>
     </div>
-    <fluent-dialog id="newly-added-domain-address-dialog" hidden trap-focus modal>
+    <fluent-dialog id="reconfirmation-dialog" hidden trap-focus modal>
         <h2 data-l10n-text-content="newlyAddedDomainReconfirmation_caption"></h2>
-        <div class="newly-added-domain-container">
-            <fluent-card id="newly-added-domains-card" class="newly-added-domain-content">
-                <p id="newly-added-domains-message-before"></p>
-                <ul id="newly-added-domain-address-list"></ul>
-                <p data-l10n-text-content="newlyAddedDomainReconfirmation_messageAfter"></p>
+        <div class="reconfirmation-container">
+            <fluent-card id="reconfirmations-card" class="reconfirmation-content">
             </fluent-card>
             <div class="new-domain-button-container">
-                <fluent-button id="send-new-domain-button" onclick="onSendNewDomain()"
-                    data-l10n-text-content="newlyAddedDomainReconfirmation_sendButtonLabel"></fluent-button>
-                <fluent-button id="cancel-new-domain-button" onclick="onCancelNewDomain()"
-                    data-l10n-text-content="newlyAddedDomainReconfirmation_cancelButtonLabel"></fluent-button>
+                <fluent-button id="ok-reconfirmation-button" onclick="onOkReconfirmation()"
+                    data-l10n-text-content="Reconfirmation_okButtonLabel"></fluent-button>
+                <fluent-button id="cancel-reconfirmation-button" onclick="onCancelReconfirmation()"
+                    data-l10n-text-content="Reconfirmation_cancelButtonLabel"></fluent-button>
             </div>
         </div>
     </fluent-dialog>

--- a/src/web/confirm.js
+++ b/src/web/confirm.js
@@ -28,7 +28,7 @@ Office.onReady(() => {
   l10n.ready.then(() => l10n.translateAll());
   safeBccConfirmation = new SafeBccConfirmation(language);
   attachmentsConfirmation = new AttachmentsConfirmation(language);
-  reconfirmation = new Reconfirmation(language);
+  reconfirmation = new Reconfirmation();
   addedDomainsReconfirmation = new AddedDomainsReconfirmation(language);
 
   document.documentElement.setAttribute("lang", language);

--- a/src/web/confirm.js
+++ b/src/web/confirm.js
@@ -217,7 +217,7 @@ async function onMessageFromParent(arg) {
   const groupedByTypeUntrusted = Object.groupBy(data.classified.untrusted, (item) => item.domain);
   appendRecipientCheckboxes(document.getElementById("untrusted-domains"), groupedByTypeUntrusted);
 
-  await safeBccConfirmation.init(data);
+  safeBccConfirmation.init(data);
   appendMiscWarningCheckboxes(safeBccConfirmation.warningConfirmationItems);
 
   appendMiscWarningCheckboxes(

--- a/src/web/reconfirmation.mjs
+++ b/src/web/reconfirmation.mjs
@@ -1,0 +1,52 @@
+/*
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+Copyright (c) 2025 ClearCode Inc.
+*/
+export class Reconfirmation {
+  needToConfirm = false;
+  confirmContents = [];
+  currentContensIndex = 0;
+
+  appendContent(content) {
+    if (!content) {
+      return;
+    }
+    this.needToConfirm = true;
+    this.confirmContents.push(content);
+  }
+
+  initUI(sendStatusToParent) {
+    window.onOkReconfirmation = () => {
+      if (this.currentContensIndex < this.confirmContents.length) {
+        this.showNextContent();
+        return;
+      }
+      document.getElementById("reconfirmation-dialog").hidden = true;
+      sendStatusToParent("ok");
+    };
+    window.onCancelReconfirmation = () => {
+      this.currentContensIndex = -1;
+      document.getElementById("reconfirmation-dialog").hidden = true;
+    };
+  }
+
+  showNextContent() {
+    this.currentContensIndex += 1;
+    if (this.currentContensIndex < 0 || this.currentContensIndex >= this.confirmContents.length) {
+      return;
+    }
+    const content = this.confirmContents[this.currentContensIndex];
+    const targetElement = document.getElementById("reconfirmations-card");
+    targetElement.innerHTML = "";
+    targetElement.appendChild(content);
+  }
+
+  show() {
+    this.currentContensIndex = -1;
+    this.showNextContent();
+    document.getElementById("reconfirmation-dialog").hidden = false;
+  }
+}

--- a/tests/unit/test-added-domains-reconfirmation.mjs
+++ b/tests/unit/test-added-domains-reconfirmation.mjs
@@ -5,10 +5,19 @@
 */
 'use strict';
 
+import * as L10nUtils from "./l10n.mjs";
 import { AddedDomainsReconfirmation } from "../../src/web/added-domains-reconfirmation.mjs";
 import * as RecipientParser from "../../src/web/recipient-parser.mjs";
 import { assert } from 'tiny-esm-test-runner';
 const { ok, ng, is } = assert;
+
+let reconfirmation;
+
+export async function setUp() {
+  L10nUtils.clear();
+  reconfirmation = new AddedDomainsReconfirmation("ja");
+  await reconfirmation.ready;
+}
 
 function toTarget(address) {
   return { 
@@ -188,7 +197,6 @@ test_shouldReconfirm.parameters = {
   },
 };
 export function test_shouldReconfirm({ data, domains }) {
-  const reconfirmation = new AddedDomainsReconfirmation();
   reconfirmation.init(data);
   ok(reconfirmation.initialized);
   ok(reconfirmation.needToConfirm);
@@ -318,7 +326,6 @@ test_shouldNotReconfirm.parameters = {
   },
 };
 export function test_shouldNotReconfirm(data) {
-  const reconfirmation = new AddedDomainsReconfirmation();
   reconfirmation.init(data);
   ok(reconfirmation.initialized);
   ng(reconfirmation.needToConfirm);


### PR DESCRIPTION
複数回再警告処理が行えるように、現在の再警告処理を改修。

本ブランチの段階では、新しいドメインが追加された場合の再警告処理しかないため、従来と実際の動作に変更はない。
この後別のブランチで、注意が必要なドメインでの再警告処理などを実装する予定のため、その準備。

### テスト

リリース前テスト手順から、関連する部分を抜粋し実施。

##### 返信の宛先に今まで含まれていなかったドメインのアドレスが追加された場合に警告する

* 「返信の宛先に今まで含まれていなかったドメインのアドレスが追加された場合に警告する」をONにする
* 「保存して閉じる」ボタンでFlexConfirmMail設定画面を閉じる
* 新しいメールを作成する
* 宛先に自分自身のアドレスを指定する
* 件名に「Test」を指定する
* 本文に「This is a test mail」を指定する
* メールを送信する
  * [x] FlexConfirmMailのメール送信確認画面が表示されること
  * [x] 赤背景の警告ダイアログが表示されないこと
* FlexConfirmMailのメール送信確認画面ですべてのチェックボックスにチェックする
* 「送信」ボタンから送信する
* 送信した自分宛てのメールを受信したことを確認する
* 送信した自分宛てのメールで返信ボタンをクリックし、編集を開始する
* 宛先に`test@example.com`を追加する
* メールを送信する
* FlexConfirmMailのメール送信確認画面ですべてのチェックボックスにチェックする
* 「送信」ボタンから送信する
  * [x] 赤背景で、以下の警告ダイアログが表示されること
    ```
    返信元のメールの宛先に含まれていなかったドメインの以下の宛先が追加されています。

    test@example.com
    送信してよろしいですか？
    ```
* 警告ダイアログで「キャンセル」ボタンをクリックする
  * [x] 警告ダイアログが閉じ、FlexConfirmMailのメール送信確認画面に戻ること
* 再度送信確認画面で「送信」ボタンから送信する
  * [x] 赤背景で、警告ダイアログが表示されること
* 警告ダイアログの「送信」ボタンをクリックする
  * [x] 送信されること
* 改めて本手順で送信した自分宛てのメールで返信ボタンをクリックし、編集を開始する
* 自分のメールアドレスと同じドメインで、別のメールアドレスを宛先に追加する
  * 例: `ippan-tarou@flexconfirmmail.com`を使用している場合、`administrator@flexconfirmmail.com`を宛先に追加する
* メールを送信する
* FlexConfirmMailのメール送信確認画面ですべてのチェックボックスにチェックする
* 「送信」ボタンから送信する
  * [x] 赤背景の警告ダイアログが表示されないこと
