### PR TITLE
Refactor app.js

### DIFF
--- a/src/web/app.js
+++ b/src/web/app.js
@@ -260,11 +260,14 @@ async function tryCountDown(data, asyncContext) {
 
 async function onItemSend(event) {
   let asyncContext = event;
-  const data = await ConfirmData.getCurrentDataAsync(
-    Office.context.mailbox.item.itemType,
-    locale
-  );
+  const data = await ConfirmData.getCurrentDataAsync(Office.context.mailbox.item.itemType, locale);
   console.debug(data);
+
+  if (data.shouldSkipAll()) {
+    asyncContext.completed({ allowEvent: true });
+    return;
+  }
+
   {
     const { allowed, asyncContext: updatedAsyncContext } = await tryConfirm(data, asyncContext);
     if (!allowed) {

--- a/src/web/app.js
+++ b/src/web/app.js
@@ -137,7 +137,7 @@ function charsToPercentage(chars, maxSize) {
 async function tryConfirm(data, asyncContext) {
   console.debug("classified: ", data.classified);
 
-  if (data.shouldBlock()) {
+  if (data.blockSending) {
     const { status, asyncContext: updatedAsyncContext } = await openDialog({
       url: window.location.origin + "/block.html",
       data,
@@ -153,7 +153,7 @@ async function tryConfirm(data, asyncContext) {
     };
   }
 
-  if (data.shouldSkipConfirm()) {
+  if (data.skipConfirm) {
     console.log("Skip confirmation: no untrusted recipient");
     return {
       allowed: true,
@@ -231,7 +231,7 @@ async function onItemSend(event) {
   const data = await ConfirmData.getCurrentDataAsync(Office.context.mailbox.item.itemType, locale);
   console.debug(data);
 
-  if (data.shouldSkipAll()) {
+  if (data.skipAll) {
     asyncContext.completed({ allowEvent: true });
     return;
   }
@@ -258,7 +258,7 @@ async function onItemSend(event) {
 
   console.debug("granted: continue to send");
 
-  if (data.shouldDelayDelivery()) {
+  if (data.delayDelivery) {
     const currentSetting = await OfficeDataAccessHelper.getDelayDeliveryTime();
     if (currentSetting == 0) {
       const currentTime = new Date().getTime();

--- a/src/web/app.js
+++ b/src/web/app.js
@@ -23,38 +23,6 @@ function sleepAsync(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-
-function getSubjectAsync() {
-  return new Promise((resolve, reject) => {
-    try {
-      Office.context.mailbox.item.subject.getAsync((asyncResult) => {
-        const subject = asyncResult.value;
-        resolve(subject);
-      });
-    } catch (error) {
-      console.log(`Error while getting subject: ${error}`);
-      reject(error);
-    }
-  });
-}
-
-function getBodyAsync() {
-  return new Promise((resolve, reject) => {
-    try {
-      Office.context.mailbox.item.body.getAsync(
-        Office.CoercionType.Html,
-        { bodyMode: Office.MailboxEnums.BodyMode.Full },
-        (asyncResult) => {
-          const body = asyncResult.value;
-          resolve(body);
-        }
-      );
-    } catch (error) {
-      console.log(`Error while getting body: ${error}`);
-      reject(error);
-    }
-  });
-}
 async function openDialog({ url, data, asyncContext, promptBeforeOpen, ...params }) {
   const asyncResult = await new Promise((resolve) => {
     Office.context.ui.displayDialogAsync(

--- a/src/web/app.js
+++ b/src/web/app.js
@@ -260,9 +260,9 @@ async function tryCountDown(data, asyncContext) {
 
 async function onItemSend(event) {
   let asyncContext = event;
-  const data = await ConfirmData.generateNewDataAsync(
+  const data = await ConfirmData.getCurrentDataAsync(
     Office.context.mailbox.item.itemType,
-    this.locale
+    locale
   );
   console.debug(data);
   {

--- a/src/web/app.js
+++ b/src/web/app.js
@@ -7,17 +7,9 @@ Copyright (c) 2025 ClearCode Inc.
 */
 import { L10n } from "./l10n.mjs";
 import { ConfigLoader } from "./config-loader.mjs";
-import * as RecipientParser from "./recipient-parser.mjs";
-import { RecipientClassifier } from "./recipient-classifier.mjs";
-import { AttachmentClassifier } from "./attachment-classifier.mjs";
+import { ConfirmData } from "./confirm-data.mjs";
+import { OfficeDataAccessHelper } from "./office-data-access-helper.mjs";
 
-const ORIGINAL_RECIPIENTS_KEY = "FCM_OriginalRecipients";
-const ORIGINAL_ATTENDEES_KEY = "FCM_OriginalAttendees";
-const CONFIRM_ATTACHMENT_TYPES = new Set([
-  // Office.MailboxEnums are not accessible before initialized.
-  "cloud", // Office.MailboxEnums.AttachmentType.Cloud,
-  "file", // Office.MailboxEnums.AttachmentType.File,
-]);
 let locale;
 
 Office.onReady(() => {
@@ -31,39 +23,6 @@ function sleepAsync(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-function getBccAsync() {
-  return new Promise((resolve, reject) => {
-    try {
-      Office.context.mailbox.item.bcc.getAsync((asyncResult) => {
-        const recipients = asyncResult.value.map((officeAddonRecipient) => ({
-          ...officeAddonRecipient,
-          ...RecipientParser.parse(officeAddonRecipient.emailAddress),
-        }));
-        resolve(recipients);
-      });
-    } catch (error) {
-      console.log(`Error while getting Bcc: ${error}`);
-      reject(error);
-    }
-  });
-}
-
-function getCcAsync() {
-  return new Promise((resolve, reject) => {
-    try {
-      Office.context.mailbox.item.cc.getAsync((asyncResult) => {
-        const recipients = asyncResult.value.map((officeAddonRecipient) => ({
-          ...officeAddonRecipient,
-          ...RecipientParser.parse(officeAddonRecipient.emailAddress),
-        }));
-        resolve(recipients);
-      });
-    } catch (error) {
-      console.log(`Error while getting Cc: ${error}`);
-      reject(error);
-    }
-  });
-}
 
 function getSubjectAsync() {
   return new Promise((resolve, reject) => {
@@ -96,235 +55,6 @@ function getBodyAsync() {
     }
   });
 }
-
-function getItemIdAsync() {
-  return new Promise((resolve, reject) => {
-    try {
-      Office.context.mailbox.item.getItemIdAsync((asyncResult) => {
-        const id = asyncResult.value;
-        resolve(id);
-      });
-    } catch (error) {
-      console.log(`Error while getting itemId: ${error}`);
-      reject(error);
-    }
-  });
-}
-
-function getRequiredAttendeeAsync() {
-  return new Promise((resolve, reject) => {
-    try {
-      Office.context.mailbox.item.requiredAttendees.getAsync((asyncResult) => {
-        const recipients = asyncResult.value.map((officeAddonRecipient) => ({
-          ...officeAddonRecipient,
-          ...RecipientParser.parse(officeAddonRecipient.emailAddress),
-        }));
-        resolve(recipients);
-      });
-    } catch (error) {
-      console.log(`Error while getting required attendees: ${error}`);
-      reject(error);
-    }
-  });
-}
-
-function getOptionalAttendeeAsync() {
-  return new Promise((resolve, reject) => {
-    try {
-      Office.context.mailbox.item.optionalAttendees.getAsync((asyncResult) => {
-        const recipients = asyncResult.value.map((officeAddonRecipient) => ({
-          ...officeAddonRecipient,
-          ...RecipientParser.parse(officeAddonRecipient.emailAddress),
-        }));
-        resolve(recipients);
-      });
-    } catch (error) {
-      console.log(`Error while getting optional attendees: ${error}`);
-      reject(error);
-    }
-  });
-}
-
-function getToAsync() {
-  return new Promise((resolve, reject) => {
-    try {
-      Office.context.mailbox.item.to.getAsync((asyncResult) => {
-        const recipients = asyncResult.value.map((officeAddonRecipient) => ({
-          ...officeAddonRecipient,
-          ...RecipientParser.parse(officeAddonRecipient.emailAddress),
-        }));
-        resolve(recipients);
-      });
-    } catch (error) {
-      console.log(`Error while getting To: ${error}`);
-      reject(error);
-    }
-  });
-}
-
-function getSessionDataAsync(key) {
-  return new Promise((resolve, reject) => {
-    try {
-      Office.context.mailbox.item.sessionData.getAsync(key, (asyncResult) => {
-        if (asyncResult.status === Office.AsyncResultStatus.Succeeded) {
-          resolve(asyncResult.value);
-        } else {
-          console.debug(`Error while getting SessionData [${key}]: ${asyncResult.error.message}`);
-          // Regards no value
-          resolve("");
-        }
-      });
-    } catch (error) {
-      console.log(`Error while getting SessionData [${key}]: ${error}`);
-      reject(error);
-    }
-  });
-}
-
-function getAttachmentsAsync() {
-  return new Promise((resolve, reject) => {
-    try {
-      Office.context.mailbox.item.getAttachmentsAsync((asyncResult) => {
-        const attachments = asyncResult.value;
-        const maybeFiles = attachments.filter((attachment) =>
-          CONFIRM_ATTACHMENT_TYPES.has(attachment.attachmentType)
-        );
-        resolve(maybeFiles);
-      });
-    } catch (error) {
-      console.log(`Error while getting attachments: ${error}`);
-      reject(error);
-    }
-  });
-}
-
-function getDelayDeliveryTime() {
-  return new Promise((resolve, reject) => {
-    try {
-      Office.context.mailbox.item.delayDeliveryTime.getAsync((asyncResult) => {
-        const value = asyncResult.value;
-        resolve(value);
-      });
-    } catch (error) {
-      console.log(`Error while getting DelayDeliveryTime: ${error}`);
-      reject(error);
-    }
-  });
-}
-
-function setDelayDeliveryTimeAsync(deliveryTime) {
-  return new Promise((resolve, reject) => {
-    try {
-      Office.context.mailbox.item.delayDeliveryTime.setAsync(deliveryTime, (asyncResult) => {
-        if (asyncResult.status === Office.AsyncResultStatus.Failed) {
-          console.log(asyncResult.error.message);
-          resolve(false);
-        } else {
-          resolve(true);
-        }
-      });
-    } catch (error) {
-      console.log(`Error while setting DelayDeliveryTime: ${error}`);
-      reject(error);
-    }
-  });
-}
-
-function setSessionDataAsync(key, value) {
-  return new Promise((resolve, reject) => {
-    try {
-      Office.context.mailbox.item.sessionData.setAsync(key, value, (asyncResult) => {
-        if (asyncResult.status === Office.AsyncResultStatus.Failed) {
-          console.log(asyncResult.error.message);
-          resolve(false);
-        } else {
-          resolve(true);
-        }
-      });
-    } catch (error) {
-      console.log(`Error while setting SessionData: ${error}`);
-      reject(error);
-    }
-  });
-}
-
-function removeSessionDataAsync(key) {
-  return new Promise((resolve, reject) => {
-    try {
-      Office.context.mailbox.item.sessionData.removeAsync(key, (asyncResult) => {
-        if (asyncResult.status === Office.AsyncResultStatus.Failed) {
-          console.log(asyncResult.error.message);
-          resolve(false);
-        } else {
-          resolve(true);
-        }
-      });
-    } catch (error) {
-      console.log(`Error while removing SessionData: ${error}`);
-      reject(error);
-    }
-  });
-}
-
-async function getAllMailData() {
-  const [to, cc, bcc, subject, body, attachments, config] = await Promise.all([
-    getToAsync(),
-    getCcAsync(),
-    getBccAsync(),
-    getSubjectAsync(),
-    getBodyAsync(),
-    getAttachmentsAsync(),
-    ConfigLoader.loadEffectiveConfig(),
-  ]);
-  let originalRecipients = {};
-  const originalRecipientsJson = await getSessionDataAsync(ORIGINAL_RECIPIENTS_KEY);
-  if (originalRecipientsJson) {
-    originalRecipients = JSON.parse(originalRecipientsJson);
-  }
-  return {
-    target: {
-      to,
-      cc,
-      bcc,
-      subject,
-      body,
-      attachments,
-    },
-    config,
-    originalRecipients,
-    itemType: Office.MailboxEnums.ItemType.Message,
-  };
-}
-
-async function getAllAppointmentData() {
-  const [requiredAttendees, optionalAttendees, subject, body, attachments, config] =
-    await Promise.all([
-      getRequiredAttendeeAsync(),
-      getOptionalAttendeeAsync(),
-      getSubjectAsync(),
-      getBodyAsync(),
-      getAttachmentsAsync(),
-      ConfigLoader.loadEffectiveConfig(),
-    ]);
-  let originalAttendees = {};
-  const originalAttendeesJson = await getSessionDataAsync(ORIGINAL_ATTENDEES_KEY);
-  if (originalAttendeesJson) {
-    originalAttendees = JSON.parse(originalAttendeesJson);
-  }
-  return {
-    target: {
-      requiredAttendees,
-      optionalAttendees,
-      subject,
-      body,
-      attachments,
-    },
-    config,
-    originalRecipients: originalAttendees,
-    itemType: Office.MailboxEnums.ItemType.Appointment,
-  };
-}
-
 async function openDialog({ url, data, asyncContext, promptBeforeOpen, ...params }) {
   const asyncResult = await new Promise((resolve) => {
     Office.context.ui.displayDialogAsync(
@@ -437,42 +167,9 @@ function charsToPercentage(chars, maxSize) {
 }
 
 async function tryConfirm(data, asyncContext) {
-  const { trustedDomains, unsafeDomains } = data.config;
-  data.classified = {};
-  switch (data.itemType) {
-    case Office.MailboxEnums.ItemType.Message: {
-      const { to, cc, bcc } = data.target;
-      data.classified.recipients = RecipientClassifier.classifyAll({
-        locale,
-        to,
-        cc,
-        bcc,
-        trustedDomains,
-        unsafeDomains,
-      });
-      break;
-    }
-    case Office.MailboxEnums.ItemType.Appointment:
-    default: {
-      const { requiredAttendees, optionalAttendees } = data.target;
-      data.classified.recipients = RecipientClassifier.classifyAll({
-        locale,
-        requiredAttendees,
-        optionalAttendees,
-        trustedDomains,
-        unsafeDomains,
-      });
-      break;
-    }
-  }
-  data.classified.attachments = AttachmentClassifier.classify(data);
   console.debug("classified: ", data.classified);
 
-  if (
-    data.classified.recipients.block.length > 0 ||
-    data.classified.recipients.blockWithDomain.length > 0 ||
-    data.classified.attachments.block.length > 0
-  ) {
+  if (data.shouldBlock()) {
     const { status, asyncContext: updatedAsyncContext } = await openDialog({
       url: window.location.origin + "/block.html",
       data,
@@ -488,7 +185,7 @@ async function tryConfirm(data, asyncContext) {
     };
   }
 
-  if (data.config.common.MainSkipIfNoExt && data.classified.recipients.untrusted.length == 0) {
+  if (data.shouldSkipConfirm()) {
     console.log("Skip confirmation: no untrusted recipient");
     return {
       allowed: true,
@@ -561,9 +258,12 @@ async function tryCountDown(data, asyncContext) {
   };
 }
 
-async function onMailSend(event) {
+async function onItemSend(event) {
   let asyncContext = event;
-  const data = await getAllMailData();
+  const data = await ConfirmData.generateNewDataAsync(
+    Office.context.mailbox.item.itemType,
+    this.locale
+  );
   console.debug(data);
   {
     const { allowed, asyncContext: updatedAsyncContext } = await tryConfirm(data, asyncContext);
@@ -587,83 +287,37 @@ async function onMailSend(event) {
 
   console.debug("granted: continue to send");
 
-  if (data.config.common?.DelayDeliveryEnabled) {
-    const currentSetting = await getDelayDeliveryTime();
+  if (data.shouldDelayDelivery()) {
+    const currentSetting = await OfficeDataAccessHelper.getDelayDeliveryTime();
     if (currentSetting == 0) {
       const currentTime = new Date().getTime();
       const delayDeliverySeconds = data.config.common?.DelayDeliverySeconds ?? 60;
       const delayInMilliseconds = delayDeliverySeconds * 1000;
       const deliveryTime = new Date(currentTime + delayInMilliseconds);
-      await setDelayDeliveryTimeAsync(deliveryTime);
+      await OfficeDataAccessHelper.setDelayDeliveryTimeAsync(deliveryTime);
     }
   }
-  if (data.originalRecipients) {
-    await removeSessionDataAsync(ORIGINAL_RECIPIENTS_KEY);
-  }
+  await OfficeDataAccessHelper.removeOriginalRecipientsSessionDataAsync(data.itemType);
   asyncContext.completed({ allowEvent: true });
-}
-
-async function onAppointmentSend(event) {
-  let asyncContext = event;
-  const data = await getAllAppointmentData();
-  console.debug(data);
-  if (!data.config.common?.AppointmentConfirmationEnabled) {
-    asyncContext.completed({ allowEvent: true });
-    return;
-  }
-
-  {
-    const { allowed, asyncContext: updatedAsyncContext } = await tryConfirm(data, asyncContext);
-    if (!allowed) {
-      console.debug("canceled by confirmation");
-      asyncContext.completed({ allowEvent: false });
-      return;
-    }
-    asyncContext = updatedAsyncContext;
-  }
-
-  {
-    const { allowed, asyncContext: updatedAsyncContext } = await tryCountDown(data, asyncContext);
-    if (!allowed) {
-      console.debug("canceled by countdown");
-      asyncContext.completed({ allowEvent: false });
-      return;
-    }
-    asyncContext = updatedAsyncContext;
-  }
-
-  console.debug("granted: continue to send");
-  if (data.originalRecipients) {
-    await removeSessionDataAsync(ORIGINAL_ATTENDEES_KEY);
-  }
-  asyncContext.completed({ allowEvent: true });
-}
-
-async function onItemSend(event) {
-  const itemType = Office.context.mailbox.item.itemType;
-  switch (itemType) {
-    case Office.MailboxEnums.ItemType.Message:
-      onMailSend(event);
-      return;
-    case Office.MailboxEnums.ItemType.Appointment:
-      onAppointmentSend(event);
-      return;
-    default:
-      event.completed({ allowEvent: true });
-      return;
-  }
 }
 window.onItemSend = onItemSend;
 
 async function onNewMessageComposeCreated(event) {
-  const [to, cc, bcc] = await Promise.all([getToAsync(), getCcAsync(), getBccAsync()]);
+  const [to, cc, bcc] = await Promise.all([
+    OfficeDataAccessHelper.getToAsync(),
+    OfficeDataAccessHelper.getCcAsync(),
+    OfficeDataAccessHelper.getBccAsync(),
+  ]);
   if (to.length > 0 || cc.length > 0 || bcc.length > 0) {
     const originalRecipients = {
       to,
       cc,
       bcc,
     };
-    await setSessionDataAsync(ORIGINAL_RECIPIENTS_KEY, JSON.stringify(originalRecipients));
+    await OfficeDataAccessHelper.setOriginalRecipientsSessionDataAsync(
+      Office.context.mailbox.item.itemType,
+      JSON.stringify(originalRecipients)
+    );
   }
   event.completed();
 }
@@ -671,8 +325,8 @@ window.onNewMessageComposeCreated = onNewMessageComposeCreated;
 
 async function onAppointmentOrganizer(event) {
   const [requiredAttendees, optionalAttendees] = await Promise.all([
-    getRequiredAttendeeAsync(),
-    getOptionalAttendeeAsync(),
+    OfficeDataAccessHelper.getRequiredAttendeeAsync(),
+    OfficeDataAccessHelper.getOptionalAttendeeAsync(),
   ]);
 
   if (Office.context.platform == Office.PlatformType.PC) {
@@ -682,7 +336,7 @@ async function onAppointmentOrganizer(event) {
     // This function has nothing to do if this is a new appointment
     // because there is no existing attendees. So return if this is a
     // new appointment.
-    const id = await getItemIdAsync();
+    const id = await OfficeDataAccessHelper.getItemIdAsync();
     if (!id) {
       // On classic Outlook, if the id is not defined, this is a new appointment.
       event.completed();
@@ -695,7 +349,10 @@ async function onAppointmentOrganizer(event) {
       requiredAttendees,
       optionalAttendees,
     };
-    await setSessionDataAsync(ORIGINAL_ATTENDEES_KEY, JSON.stringify(originalAttendees));
+    await OfficeDataAccessHelper.setOriginalRecipientsSessionDataAsync(
+      Office.context.mailbox.item.itemType,
+      JSON.stringify(originalAttendees)
+    );
   }
   event.completed();
 }

--- a/src/web/confirm-data.mjs
+++ b/src/web/confirm-data.mjs
@@ -1,0 +1,124 @@
+/*
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+Copyright (c) 2025 ClearCode Inc.
+*/
+import { RecipientClassifier } from "./recipient-classifier.mjs";
+import { AttachmentClassifier } from "./attachment-classifier.mjs";
+import { ConfigLoader } from "./config-loader.mjs";
+import { OfficeDataAccessHelper } from "./office-data-access-helper.mjs";
+
+// The data scheme:
+// data = {
+//   target: {
+//     to : [{emailAddress:"mail@example.com"}, ...],
+//     cc : [...],
+//     bcc : [...],
+//     requiredAttendees : [...],
+//     optionalAttendees : [...],
+//     attachments: [{name:"...",size:0,isInline:false}, ...],
+//   },
+//   config: {
+//     trustedDomains : ["example.com", ...],
+//     unsafeDomains : { "WARNING": [...] } ,
+//     unsafeFiles : { "WARNING": [...] },
+//   },
+//   originalRecipients: {
+//     to : [...],
+//     cc : [...],
+//     bcc : [...],
+//   },
+//   classified: {
+//     { recipients:
+//       trusted: [...],
+//       untrusted: [...],
+//       unsafeWithDomain: [...],
+//       unsafe: [...],
+//       blockWithDomain: [...],
+//       block: [...],
+//     }
+//   },
+//   itemType: Office.MailboxEnums.ItemType.Message,
+// }
+export class ConfirmData {
+  target;
+  config;
+  originalRecipients;
+  classified;
+  itemType;
+
+  constructor({ target, config, originalRecipients, itemType, classified }) {
+    this.target = target;
+    this.config = config;
+    this.originalRecipients = originalRecipients;
+    this.itemType = itemType;
+    this.classified = classified;
+  }
+
+  classifyTarget(locale) {
+    if (this.classified) {
+      return;
+    }
+    this.classified = {};
+    const { trustedDomains, unsafeDomains } = this.config;
+    switch (this.itemType) {
+      case Office.MailboxEnums.ItemType.Message: {
+        const { to, cc, bcc } = this.target;
+        this.classified.recipients = RecipientClassifier.classifyAll({
+          locale,
+          to,
+          cc,
+          bcc,
+          trustedDomains,
+          unsafeDomains,
+        });
+        break;
+      }
+      case Office.MailboxEnums.ItemType.Appointment:
+      default: {
+        const { requiredAttendees, optionalAttendees } = this.target;
+        this.classified.recipients = RecipientClassifier.classifyAll({
+          locale,
+          requiredAttendees,
+          optionalAttendees,
+          trustedDomains,
+          unsafeDomains,
+        });
+        break;
+      }
+    }
+    this.classified.attachments = AttachmentClassifier.classify(this);
+  }
+
+  shouldBlock() {
+    return (
+      this.classified.recipients.block.length > 0 ||
+      this.classified.recipients.blockWithDomain.length > 0 ||
+      this.classified.attachments.block.length > 0
+    );
+  }
+
+  shouldSkipConfirm() {
+    return this.config.common.MainSkipIfNoExt && this.classified.recipients.untrusted.length == 0;
+  }
+
+  shouldDelayDelivery() {
+    return (
+      this.itemType === Office.MailboxEnums.ItemType.Message &&
+      this.config.common?.DelayDeliveryEnabled
+    );
+  }
+
+  static async generateNewDataAsync(itemType, locale) {
+    const messageData =
+      itemType == Office.MailboxEnums.ItemType.Message
+        ? await OfficeDataAccessHelper.getAllMailData()
+        : await OfficeDataAccessHelper.getAllAppointmentData();
+    const confirmData = new ConfirmData(messageData);
+    confirmData.config = await ConfigLoader.loadEffectiveConfig();
+    confirmData.classifyTarget(locale);
+    return confirmData;
+  }
+}

--- a/src/web/confirm-data.mjs
+++ b/src/web/confirm-data.mjs
@@ -111,6 +111,14 @@ export class ConfirmData {
     );
   }
 
+  shouldSkipAll() {
+    const appointmentConfirmationEnabled =
+      this.config.common?.AppointmentConfirmationEnabled ?? false;
+    return (
+      this.itemType === Office.MailboxEnums.ItemType.Appointment && !appointmentConfirmationEnabled
+    );
+  }
+
   static async getCurrentDataAsync(itemType, locale) {
     const messageData =
       itemType == Office.MailboxEnums.ItemType.Message

--- a/src/web/confirm-data.mjs
+++ b/src/web/confirm-data.mjs
@@ -111,7 +111,7 @@ export class ConfirmData {
     );
   }
 
-  static async generateNewDataAsync(itemType, locale) {
+  static async getCurrentDataAsync(itemType, locale) {
     const messageData =
       itemType == Office.MailboxEnums.ItemType.Message
         ? await OfficeDataAccessHelper.getAllMailData()

--- a/src/web/confirm-data.mjs
+++ b/src/web/confirm-data.mjs
@@ -92,7 +92,7 @@ export class ConfirmData {
     this.classified.attachments = AttachmentClassifier.classify(this);
   }
 
-  shouldBlock() {
+  get blockSending() {
     return (
       this.classified.recipients.block.length > 0 ||
       this.classified.recipients.blockWithDomain.length > 0 ||
@@ -100,18 +100,18 @@ export class ConfirmData {
     );
   }
 
-  shouldSkipConfirm() {
+  get skipConfirm() {
     return this.config.common.MainSkipIfNoExt && this.classified.recipients.untrusted.length == 0;
   }
 
-  shouldDelayDelivery() {
+  get delayDelivery() {
     return (
       this.itemType === Office.MailboxEnums.ItemType.Message &&
       this.config.common?.DelayDeliveryEnabled
     );
   }
 
-  shouldSkipAll() {
+  get skipAll() {
     const appointmentConfirmationEnabled =
       this.config.common?.AppointmentConfirmationEnabled ?? false;
     return (

--- a/src/web/confirm.js
+++ b/src/web/confirm.js
@@ -7,8 +7,9 @@ Copyright (c) 2025 ClearCode Inc.
 */
 import { L10n } from "./l10n.mjs";
 import { SafeBccConfirmation } from "./safe-bcc-confirmation.mjs";
-import { Reconfirmation } from "./reconfirmation.mjs";
 import { AddedDomainsReconfirmation } from "./added-domains-reconfirmation.mjs";
+import { Reconfirmation } from "./reconfirmation.mjs";
+import { ConfirmData } from "./confirm-data.mjs";
 import { UnsafeDomainsReconfirmation } from "./unsafe-domains-reconfirmation.mjs";
 import { UnsafeAddressesReconfirmation } from "./unsafe-addresses-reconfirmation.mjs";
 import * as Dialog from "./dialog.mjs";
@@ -176,42 +177,9 @@ function appendCheckbox({ container, id, label, warning }) {
 }
 
 async function onMessageFromParent(arg) {
-  const data = JSON.parse(arg.message);
-
-  // The data scheme:
-  // data = {
-  //   target: {
-  //     to : [{emailAddress:"mail@example.com"}, ...],
-  //     cc : [...],
-  //     bcc : [...],
-  //     requiredAttendees : [...],
-  //     optionalAttendees : [...],
-  //     attachments: [{name:"...",size:0,isInline:false}, ...],
-  //   },
-  //   config: {
-  //     trustedDomains : ["example.com", ...],
-  //     unsafeDomains : [...],
-  //     unsafeFiles : [...],
-  //   },
-  //   originalRecipients: {
-  //     to : [...],
-  //     cc : [...],
-  //     bcc : [...],
-  //   },
-  //   classified: {
-  //     { recipients:
-  //       trusted: [...],
-  //       untrusted: [...],
-  //       unsafeWithDomain: [...],
-  //       unsafe: [...],
-  //       blockWithDomain: [...],
-  //       block: [...],
-  //     }
-  //   },
-  //   itemType: Office.MailboxEnums.ItemType.Message,
-  // }
-
-  console.log(data);
+  const receivedData = JSON.parse(arg.message);
+  console.log(receivedData);
+  const data = new ConfirmData(receivedData);
   await Promise.all([
     l10n.ready,
     safeBccConfirmation.loaded,

--- a/src/web/confirm.js
+++ b/src/web/confirm.js
@@ -8,12 +8,12 @@ Copyright (c) 2025 ClearCode Inc.
 import { L10n } from "./l10n.mjs";
 import { SafeBccConfirmation } from "./safe-bcc-confirmation.mjs";
 import { AddedDomainsReconfirmation } from "./added-domains-reconfirmation.mjs";
-import { Reconfirmation } from "./reconfirmation.mjs";
 import { ConfirmData } from "./confirm-data.mjs";
+import { Reconfirmation } from "./reconfirmation.mjs";
 import { UnsafeDomainsReconfirmation } from "./unsafe-domains-reconfirmation.mjs";
 import { UnsafeAddressesReconfirmation } from "./unsafe-addresses-reconfirmation.mjs";
-import * as Dialog from "./dialog.mjs";
 import { UnsafeFilesReconfirmation } from "./unsafe-files-reconfirmation.mjs";
+import * as Dialog from "./dialog.mjs";
 
 let l10n;
 let safeBccConfirmation;

--- a/src/web/office-data-access-helper.mjs
+++ b/src/web/office-data-access-helper.mjs
@@ -1,0 +1,327 @@
+/*
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+Copyright (c) 2025 ClearCode Inc.
+*/
+import * as RecipientParser from "./recipient-parser.mjs";
+
+export class OfficeDataAccessHelper {
+  static ORIGINAL_RECIPIENTS_KEY = "FCM_OriginalRecipients";
+  static ORIGINAL_ATTENDEES_KEY = "FCM_OriginalAttendees";
+  static CONFIRM_ATTACHMENT_TYPES = new Set([
+    // Office.MailboxEnums are not accessible before initialized.
+    "cloud", // Office.MailboxEnums.AttachmentType.Cloud,
+    "file", // Office.MailboxEnums.AttachmentType.File,
+  ]);
+
+  static getBccAsync() {
+    return new Promise((resolve, reject) => {
+      try {
+        Office.context.mailbox.item.bcc.getAsync((asyncResult) => {
+          const recipients = asyncResult.value.map((officeAddonRecipient) => ({
+            ...officeAddonRecipient,
+            ...RecipientParser.parse(officeAddonRecipient.emailAddress),
+          }));
+          resolve(recipients);
+        });
+      } catch (error) {
+        console.log(`Error while getting Bcc: ${error}`);
+        reject(error);
+      }
+    });
+  }
+
+  static getCcAsync() {
+    return new Promise((resolve, reject) => {
+      try {
+        Office.context.mailbox.item.cc.getAsync((asyncResult) => {
+          const recipients = asyncResult.value.map((officeAddonRecipient) => ({
+            ...officeAddonRecipient,
+            ...RecipientParser.parse(officeAddonRecipient.emailAddress),
+          }));
+          resolve(recipients);
+        });
+      } catch (error) {
+        console.log(`Error while getting Cc: ${error}`);
+        reject(error);
+      }
+    });
+  }
+
+  static getSubjectAsync() {
+    return new Promise((resolve, reject) => {
+      try {
+        Office.context.mailbox.item.subject.getAsync((asyncResult) => {
+          const subject = asyncResult.value;
+          resolve(subject);
+        });
+      } catch (error) {
+        console.log(`Error while getting subject: ${error}`);
+        reject(error);
+      }
+    });
+  }
+
+  static getBodyAsync() {
+    return new Promise((resolve, reject) => {
+      try {
+        Office.context.mailbox.item.body.getAsync(
+          Office.CoercionType.Html,
+          { bodyMode: Office.MailboxEnums.BodyMode.Full },
+          (asyncResult) => {
+            const body = asyncResult.value;
+            resolve(body);
+          }
+        );
+      } catch (error) {
+        console.log(`Error while getting body: ${error}`);
+        reject(error);
+      }
+    });
+  }
+
+  static getItemIdAsync() {
+    return new Promise((resolve, reject) => {
+      try {
+        Office.context.mailbox.item.getItemIdAsync((asyncResult) => {
+          const id = asyncResult.value;
+          resolve(id);
+        });
+      } catch (error) {
+        console.log(`Error while getting itemId: ${error}`);
+        reject(error);
+      }
+    });
+  }
+
+  static getRequiredAttendeeAsync() {
+    return new Promise((resolve, reject) => {
+      try {
+        Office.context.mailbox.item.requiredAttendees.getAsync((asyncResult) => {
+          const recipients = asyncResult.value.map((officeAddonRecipient) => ({
+            ...officeAddonRecipient,
+            ...RecipientParser.parse(officeAddonRecipient.emailAddress),
+          }));
+          resolve(recipients);
+        });
+      } catch (error) {
+        console.log(`Error while getting required attendees: ${error}`);
+        reject(error);
+      }
+    });
+  }
+
+  static getOptionalAttendeeAsync() {
+    return new Promise((resolve, reject) => {
+      try {
+        Office.context.mailbox.item.optionalAttendees.getAsync((asyncResult) => {
+          const recipients = asyncResult.value.map((officeAddonRecipient) => ({
+            ...officeAddonRecipient,
+            ...RecipientParser.parse(officeAddonRecipient.emailAddress),
+          }));
+          resolve(recipients);
+        });
+      } catch (error) {
+        console.log(`Error while getting optional attendees: ${error}`);
+        reject(error);
+      }
+    });
+  }
+
+  static getToAsync() {
+    return new Promise((resolve, reject) => {
+      try {
+        Office.context.mailbox.item.to.getAsync((asyncResult) => {
+          const recipients = asyncResult.value.map((officeAddonRecipient) => ({
+            ...officeAddonRecipient,
+            ...RecipientParser.parse(officeAddonRecipient.emailAddress),
+          }));
+          resolve(recipients);
+        });
+      } catch (error) {
+        console.log(`Error while getting To: ${error}`);
+        reject(error);
+      }
+    });
+  }
+
+  static getSessionDataAsync(key) {
+    return new Promise((resolve, reject) => {
+      try {
+        Office.context.mailbox.item.sessionData.getAsync(key, (asyncResult) => {
+          if (asyncResult.status === Office.AsyncResultStatus.Succeeded) {
+            resolve(asyncResult.value);
+          } else {
+            console.debug(`Error while getting SessionData [${key}]: ${asyncResult.error.message}`);
+            // Regards no value
+            resolve("");
+          }
+        });
+      } catch (error) {
+        console.log(`Error while getting SessionData [${key}]: ${error}`);
+        reject(error);
+      }
+    });
+  }
+
+  static getAttachmentsAsync() {
+    return new Promise((resolve, reject) => {
+      try {
+        Office.context.mailbox.item.getAttachmentsAsync((asyncResult) => {
+          const attachments = asyncResult.value;
+          const maybeFiles = attachments.filter((attachment) =>
+            OfficeDataAccessHelper.CONFIRM_ATTACHMENT_TYPES.has(attachment.attachmentType)
+          );
+          resolve(maybeFiles);
+        });
+      } catch (error) {
+        console.log(`Error while getting attachments: ${error}`);
+        reject(error);
+      }
+    });
+  }
+
+  static getDelayDeliveryTime() {
+    return new Promise((resolve, reject) => {
+      try {
+        Office.context.mailbox.item.delayDeliveryTime.getAsync((asyncResult) => {
+          const value = asyncResult.value;
+          resolve(value);
+        });
+      } catch (error) {
+        console.log(`Error while getting DelayDeliveryTime: ${error}`);
+        reject(error);
+      }
+    });
+  }
+
+  static setDelayDeliveryTimeAsync(deliveryTime) {
+    return new Promise((resolve, reject) => {
+      try {
+        Office.context.mailbox.item.delayDeliveryTime.setAsync(deliveryTime, (asyncResult) => {
+          if (asyncResult.status === Office.AsyncResultStatus.Failed) {
+            console.log(asyncResult.error.message);
+            resolve(false);
+          } else {
+            resolve(true);
+          }
+        });
+      } catch (error) {
+        console.log(`Error while setting DelayDeliveryTime: ${error}`);
+        reject(error);
+      }
+    });
+  }
+
+  static setSessionDataAsync(key, value) {
+    return new Promise((resolve, reject) => {
+      try {
+        Office.context.mailbox.item.sessionData.setAsync(key, value, (asyncResult) => {
+          if (asyncResult.status === Office.AsyncResultStatus.Failed) {
+            console.log(asyncResult.error.message);
+            resolve(false);
+          } else {
+            resolve(true);
+          }
+        });
+      } catch (error) {
+        console.log(`Error while setting SessionData: ${error}`);
+        reject(error);
+      }
+    });
+  }
+
+  static removeSessionDataAsync(key) {
+    return new Promise((resolve, reject) => {
+      try {
+        Office.context.mailbox.item.sessionData.removeAsync(key, (asyncResult) => {
+          if (asyncResult.status === Office.AsyncResultStatus.Failed) {
+            console.log(asyncResult.error.message);
+            resolve(false);
+          } else {
+            resolve(true);
+          }
+        });
+      } catch (error) {
+        console.log(`Error while removing SessionData: ${error}`);
+        reject(error);
+      }
+    });
+  }
+
+  async setOriginalRecipientsSessionDataAsync(itemType, value) {
+    const key =
+      itemType == Office.MailboxEnums.ItemType.Message
+        ? OfficeDataAccessHelper.ORIGINAL_RECIPIENTS_KEY
+        : OfficeDataAccessHelper.ORIGINAL_ATTENDEES_KEY;
+    await OfficeDataAccessHelper.setSessionDataAsync(key, value);
+  }
+
+  async removeOriginalRecipientsSessionDataAsync(itemType) {
+    const key =
+      itemType == Office.MailboxEnums.ItemType.Message
+        ? OfficeDataAccessHelper.ORIGINAL_RECIPIENTS_KEY
+        : OfficeDataAccessHelper.ORIGINAL_ATTENDEES_KEY;
+    await OfficeDataAccessHelper.removeSessionDataAsync(key);
+  }
+
+  static async getAllMailData() {
+    const [to, cc, bcc, subject, body, attachments] = await Promise.all([
+      OfficeDataAccessHelper.getToAsync(),
+      OfficeDataAccessHelper.getCcAsync(),
+      OfficeDataAccessHelper.getBccAsync(),
+      OfficeDataAccessHelper.getSubjectAsync(),
+      OfficeDataAccessHelper.getBodyAsync(),
+      OfficeDataAccessHelper.getAttachmentsAsync(),
+    ]);
+    let originalRecipients = {};
+    const originalRecipientsJson = await OfficeDataAccessHelper.getSessionDataAsync(
+      OfficeDataAccessHelper.ORIGINAL_RECIPIENTS_KEY
+    );
+    if (originalRecipientsJson) {
+      originalRecipients = JSON.parse(originalRecipientsJson);
+    }
+    return {
+      target: {
+        to,
+        cc,
+        bcc,
+        subject,
+        body,
+        attachments,
+      },
+      originalRecipients,
+      itemType: Office.MailboxEnums.ItemType.Message,
+    };
+  }
+
+  static async getAllAppointmentData() {
+    const [requiredAttendees, optionalAttendees, subject, body, attachments] = await Promise.all([
+      OfficeDataAccessHelper.getRequiredAttendeeAsync(),
+      OfficeDataAccessHelper.getOptionalAttendeeAsync(),
+      OfficeDataAccessHelper.getSubjectAsync(),
+      OfficeDataAccessHelper.getBodyAsync(),
+      OfficeDataAccessHelper.getAttachmentsAsync(),
+    ]);
+    let originalAttendees = {};
+    const originalAttendeesJson = await OfficeDataAccessHelper.getSessionDataAsync(
+      OfficeDataAccessHelper.ORIGINAL_ATTENDEES_KEY
+    );
+    if (originalAttendeesJson) {
+      originalAttendees = JSON.parse(originalAttendeesJson);
+    }
+    return {
+      target: {
+        requiredAttendees,
+        optionalAttendees,
+        subject,
+        body,
+        attachments,
+      },
+      originalRecipients: originalAttendees,
+      itemType: Office.MailboxEnums.ItemType.Appointment,
+    };
+  }
+}

--- a/src/web/office-data-access-helper.mjs
+++ b/src/web/office-data-access-helper.mjs
@@ -251,7 +251,7 @@ export class OfficeDataAccessHelper {
     });
   }
 
-  async setOriginalRecipientsSessionDataAsync(itemType, value) {
+  static async setOriginalRecipientsSessionDataAsync(itemType, value) {
     const key =
       itemType == Office.MailboxEnums.ItemType.Message
         ? OfficeDataAccessHelper.ORIGINAL_RECIPIENTS_KEY
@@ -259,7 +259,7 @@ export class OfficeDataAccessHelper {
     await OfficeDataAccessHelper.setSessionDataAsync(key, value);
   }
 
-  async removeOriginalRecipientsSessionDataAsync(itemType) {
+  static async removeOriginalRecipientsSessionDataAsync(itemType) {
     const key =
       itemType == Office.MailboxEnums.ItemType.Message
         ? OfficeDataAccessHelper.ORIGINAL_RECIPIENTS_KEY


### PR DESCRIPTION
## Overview

* Separate office data access process to a new file
* Add a new class to manage confirmation data

## Test

* Do `## アドイン動作（全てのOutlookクライアントで確認）` -> `### GUIによるユーザーパラメータ設定` -> `#### 一般設定` in PreReleaseTest.md of the FlexConfirmMail-Outlook-Office-Addin-Enterprise repository for each client.
  * [x] Confirm that all tests pass