### PR TITLE
confirm.css: specify "height: auto" to fluent-card

### DIFF
--- a/src/web/confirm.css
+++ b/src/web/confirm.css
@@ -76,6 +76,7 @@ fluent-dialog .newly-added-domain-content strong {
 }
 
 fluent-card {
+  height: auto;
   margin-top: 10px;
   margin-bottom: 10px;
   padding-bottom: 10px;


### PR DESCRIPTION
This is a cherry pick of https://github.com/FlexConfirmMail/Outlook-Office-Addin/pull/101 for maintenance-1.0.0.0.


The fluent card height was limited and we could not display all items if there is a lot of recipients.

<img width="1228" height="651" alt="image" src="https://github.com/user-attachments/assets/3833f418-e652-4761-a2eb-0bd6994bf01e" />

This patch makes the height of the fluent card unlimited.

<img width="697" height="713" alt="image" src="https://github.com/user-attachments/assets/80392c79-36ab-450b-a8d5-e990d0657a12" />

### Test

* Create a new mail.
* Specify the following address as recipient
  * test@external0.com
  * test@external1.com
  * test@external2.com
  * test@external3.com
  * test@external4.com
  * test@external5.com
  * test@external6.com
  * test@external7.com
  * test@external8.com
  * test@external9.com
  * test@external10.com
  * test@external11.com
  * test@external12.com
  * test@external13.com
  * test@external14.com
  * test@external15.com
  * test@external16.com
  * test@external17.com
  * test@external18.com
  * test@external19.com
* Click "send"
  * [x] Confirm that the confirmation dialog is displayed.
  * [x] Confirm that all of recipients are displayed in the externals block.