### PR TITLE
app.js: reduce sleep time when a previous dialog is not closed

### DIFF
--- a/src/web/app.js
+++ b/src/web/app.js
@@ -306,7 +306,7 @@ async function openDialog({ url, data, asyncContext, promptBeforeOpen, ...params
         console.log(
           "could not open dialog before the previous dialog is not closed completely, so we need to retry it manually."
         );
-        await sleepAsync(1000);
+        await sleepAsync(200);
         return openDialog({ url, data, asyncContext, ...params });
 
       case 12011:


### PR DESCRIPTION
When displaying the count-down dialog, the error 12007 (the previous dialog is not closed completely) always occurs.
In such case, FlexConfirmMail waits (sleeps) 1 second to close the previous dialog, but it is long a bit, this sleep causes a delay of at least one second each time before the countdown dialog appears.

So we should reduce the sleep time when a previous dialog is not closed completely from 1 second to 0.2 second.