### PR TITLE
Add support for re-warning on unsafe bodies

### DIFF
--- a/src/web/added-domains-reconfirmation.mjs
+++ b/src/web/added-domains-reconfirmation.mjs
@@ -70,7 +70,7 @@ export class AddedDomainsReconfirmation {
     this.needToReconfirm = this.newDomainAddresses.size > 0;
   }
 
-  generateReconfirmationContentElement() {
+  generateReconfirmationContentElements() {
     const messageBeforeElement = document.createElement("p");
     const listElement = document.createElement("ul");
     listElement.classList.add("reconfirmation-list");
@@ -91,6 +91,6 @@ export class AddedDomainsReconfirmation {
     contentElement.appendChild(messageBeforeElement);
     contentElement.appendChild(listElement);
     contentElement.appendChild(messageAfterElement);
-    return contentElement;
+    return [contentElement];
   }
 }

--- a/src/web/config.mjs
+++ b/src/web/config.mjs
@@ -173,10 +173,12 @@ export class Config {
     FixedParameters: "commaSeparatedValues",
   };
   static unsafeBodiesParamDefs = {
+    WarningType: "text",
     Message: "text",
     Keywords: "commaSeparatedValues",
   };
-  static unsafeArraySectionDefs = ["WARNING", "BLOCK", "REWARNING"];
+  static unsafeWarningTypeDefs = ["WARNING", "BLOCK", "REWARNING"];
+  static unsafeArraySectionDefs = Config.unsafeWarningTypeDefs;
   static defaultUnsafeDomainsConfigSection = "WARNING";
   static defaultUnsafeFilesConfigSection = "WARNING";
 

--- a/src/web/confirm.js
+++ b/src/web/confirm.js
@@ -190,6 +190,7 @@ async function onMessageFromParent(arg) {
     unsafeDomainsReconfirmation.loaded,
     unsafeAddressesReconfirmation.loaded,
     unsafeFilesReconfirmation.loaded,
+    unsafeBodiesConfirmation.loaded,
   ]);
 
   if (data.classified.recipients.trusted.length == 0) {
@@ -259,14 +260,16 @@ async function onMessageFromParent(arg) {
     unsafeDomainsReconfirmation,
     unsafeAddressesReconfirmation,
     unsafeFilesReconfirmation,
+    unsafeBodiesConfirmation,
     safeBccConfirmation,
   ]) {
     reconfirmationChecker.init(data);
     if (!reconfirmationChecker.needToReconfirm) {
       continue;
     }
-    const content = reconfirmationChecker.generateReconfirmationContentElement();
-    reconfirmation.appendContent(content);
+    for (const content of reconfirmationChecker.generateReconfirmationContentElements()) {
+      reconfirmation.appendContent(content);
+    }
   }
   Dialog.resizeToContent();
 }

--- a/src/web/safe-bcc-confirmation.mjs
+++ b/src/web/safe-bcc-confirmation.mjs
@@ -46,7 +46,7 @@ export class SafeBccConfirmation {
     this.itemType = data.itemType;
   }
 
-  generateReconfirmationContentElement() {
+  generateReconfirmationContentElements() {
     const strongElement = document.createElement("strong");
     strongElement.textContent =
       this.itemType === Office.MailboxEnums.ItemType.Message
@@ -63,7 +63,7 @@ export class SafeBccConfirmation {
     messageBodyElement.appendChild(strongElement);
     contentElement.appendChild(messageBodyElement);
     contentElement.appendChild(messageAfterElement);
-    return contentElement;
+    return [contentElement];
   }
 
   get warningConfirmationItems() {

--- a/src/web/unsafe-addresses-reconfirmation.mjs
+++ b/src/web/unsafe-addresses-reconfirmation.mjs
@@ -31,7 +31,7 @@ export class UnsafeAddressesReconfirmation {
     this.needToReconfirm = this.rewarningAddresses.size > 0;
   }
 
-  generateReconfirmationContentElement() {
+  generateReconfirmationContentElements() {
     const messageBeforeElement = document.createElement("p");
     const listElement = document.createElement("ul");
     listElement.classList.add("reconfirmation-list");
@@ -49,6 +49,6 @@ export class UnsafeAddressesReconfirmation {
     contentElement.appendChild(messageBeforeElement);
     contentElement.appendChild(listElement);
     contentElement.appendChild(messageAfterElement);
-    return contentElement;
+    return [contentElement];
   }
 }

--- a/src/web/unsafe-bodies-confirmation.mjs
+++ b/src/web/unsafe-bodies-confirmation.mjs
@@ -6,13 +6,18 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 Copyright (c) 2025 ClearCode Inc.
 */
 import { wildcardToRegexp } from "./wildcard-to-regexp.mjs";
+import { L10n } from "./l10n.mjs";
 
 export class UnsafeBodiesConfirmation {
   constructor(language) {
     this.language = language;
     this.needToConfirm = false;
+    this.needToReconfirm = false;
     this.initialized = false;
     this.confirmationMessages = [];
+    this.reconfirmationMessages = [];
+    this.locale = L10n.get(language);
+    this.ready = this.locale.ready;
   }
 
   static generateMatcher(patterns) {
@@ -90,31 +95,38 @@ export class UnsafeBodiesConfirmation {
       }
       const matcher = UnsafeBodiesConfirmation.generateMatcher(config.Keywords);
       if (matcher.test(bodyText)) {
-        this.confirmationMessages.push(config.Message);
+        const warningType = config.WarningType?.toUpperCase();
+        switch (warningType) {
+          case "WARNING":
+          default:
+            this.confirmationMessages.push(config.Message);
+            break;
+          case "REWARNING":
+            this.reconfirmationMessages.push(config.Message);
+            break;
+        }
       }
     }
     this.needToConfirm = this.confirmationMessages.length >= 1;
+    this.needToReconfirm = this.reconfirmationMessages.length >= 1;
   }
 
-  // generateReconfirmationContentElement() {
-  //   const strongElement = document.createElement("strong");
-  //   strongElement.textContent =
-  //     this.itemType === Office.MailboxEnums.ItemType.Message
-  //       ? this.locale.get("Reconfirmation_safeBccReconfirmationThresholdWarning", {
-  //           threshold: this.reconfirmationThreshold,
-  //         })
-  //       : this.locale.get("Reconfirmation_safeBccReconfirmationThresholdAttendeesWarning", {
-  //           threshold: this.reconfirmationThreshold,
-  //         });
-  //   const messageAfterElement = document.createElement("p");
-  //   messageAfterElement.textContent = this.locale.get("Reconfirmation_confirmToSend");
-  //   const contentElement = document.createElement("div");
-  //   const messageBodyElement = document.createElement("p");
-  //   messageBodyElement.appendChild(strongElement);
-  //   contentElement.appendChild(messageBodyElement);
-  //   contentElement.appendChild(messageAfterElement);
-  //   return contentElement;
-  // }
+  generateReconfirmationContentElements() {
+    const contentElements = [];
+    for (const message of this.reconfirmationMessages) {
+      const strongElement = document.createElement("strong");
+      strongElement.textContent = message;
+      const messageAfterElement = document.createElement("p");
+      messageAfterElement.textContent = this.locale.get("Reconfirmation_confirmToSend");
+      const contentElement = document.createElement("div");
+      const messageBodyElement = document.createElement("pre");
+      messageBodyElement.appendChild(strongElement);
+      contentElement.appendChild(messageBodyElement);
+      contentElement.appendChild(messageAfterElement);
+      contentElements.push(contentElement);
+    }
+    return contentElements;
+  }
 
   get warningConfirmationItems() {
     return this.confirmationMessages;

--- a/src/web/unsafe-domains-reconfirmation.mjs
+++ b/src/web/unsafe-domains-reconfirmation.mjs
@@ -31,7 +31,7 @@ export class UnsafeDomainsReconfirmation {
     this.needToReconfirm = this.rewarningDomains.size > 0;
   }
 
-  generateReconfirmationContentElement() {
+  generateReconfirmationContentElements() {
     const messageBeforeElement = document.createElement("p");
     const listElement = document.createElement("ul");
     listElement.classList.add("reconfirmation-list");
@@ -49,6 +49,6 @@ export class UnsafeDomainsReconfirmation {
     contentElement.appendChild(messageBeforeElement);
     contentElement.appendChild(listElement);
     contentElement.appendChild(messageAfterElement);
-    return contentElement;
+    return [contentElement];
   }
 }

--- a/src/web/unsafe-files-reconfirmation.mjs
+++ b/src/web/unsafe-files-reconfirmation.mjs
@@ -30,7 +30,7 @@ export class UnsafeFilesReconfirmation {
     this.needToReconfirm = this.rewarningFiles.size > 0;
   }
 
-  generateReconfirmationContentElement() {
+  generateReconfirmationContentElements() {
     const messageBeforeElement = document.createElement("p");
     const listElement = document.createElement("ul");
     listElement.classList.add("reconfirmation-list");
@@ -48,6 +48,6 @@ export class UnsafeFilesReconfirmation {
     contentElement.appendChild(messageBeforeElement);
     contentElement.appendChild(listElement);
     contentElement.appendChild(messageAfterElement);
-    return contentElement;
+    return [contentElement];
   }
 }


### PR DESCRIPTION
Add suport for re-warning on unsafe bodies.

We can specify re-warning with specifying "WarningType=REWARNING" in the unsafe bodies config.

```
[Section1]
Keywords=添付
Message=[警告] 「添付」が含まれています。
WarningType=REWARNING
```

The re-warning dialog is displayed when a body contains a re-warning type keywords.

<img width="689" height="653" alt="image" src="https://github.com/user-attachments/assets/a2163abf-b5dd-42f5-a418-2bedd14d1951" />

## Test

