### PR TITLE
Add feature to block unsafe bodies

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -23,6 +23,9 @@
   "block_messageBeforeForMailAttachments": "The mail cannot be sent because its attachments contain forbidden files.",
   "block_messageBeforeForAppointmentAttachments": "The appointment cannot be sent because its attachments contain forbidden files.",
   "block_messageAfterForAttachments": "Please change the attachments.",
+  "block_messageBeforeForMailBodies": "The mail cannot be sent because its body contains forbidden words.",
+  "block_messageBeforeForAppointmentBodies": "The appointment cannot be sent because its body contains forbidden words.",
+  "block_messageAfterForBodies": "Please change the body",
 
   "newlyAddedDomainReconfirmation_caption": "CAUTION!",
   "newlyAddedDomainReconfirmation_messageBefore": "There are recipients with domains not included in the recipients of the original message.",

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -23,6 +23,9 @@
   "block_messageBeforeForMailAttachments": "送信が禁止されたファイルが添付されているため、メールを送信できません。",
   "block_messageBeforeForAppointmentAttachments": "送信が禁止されたファイルが添付されているため、予定を送信できません。",
   "block_messageAfterForAttachments": "添付ファイルを変更してください。",
+  "block_messageBeforeForMailBodies": "送信が禁止された文字列が本文に記載されているため、メールを送信できません。",
+  "block_messageBeforeForAppointmentBodies": "送信が禁止された文字列が本文が記載されているため、予定を送信できません。",
+  "block_messageAfterForBodies": "本文を変更してください。",
 
   "newlyAddedDomainReconfirmation_caption": "CAUTION!",
   "newlyAddedDomainReconfirmation_messageBefore": "返信元のメールの宛先に含まれていなかったドメインの以下の宛先が追加されています。",

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -23,6 +23,9 @@
   "block_messageBeforeForMailAttachments": "The mail cannot be sent because its attachments contains forbidden files.",
   "block_messageBeforeForAppointmentAttachments": "The appointment cannot be sent because its attachments contains forbidden files.",
   "block_messageAfterForAttachments": "Please change the attachments.",
+  "block_messageBeforeForMailBodies": "The mail cannot be sent because its body contains forbidden words.",
+  "block_messageBeforeForAppointmentBodies": "The appointment cannot be sent because its body contains forbidden words.",
+  "block_messageAfterForBodies": "Please change the body",
 
   "newlyAddedDomainReconfirmation_caption": "警告！",
   "newlyAddedDomainReconfirmation_messageBefore": "收件人添加了以下原邮件收件人中未包含的域名地址。",

--- a/src/web/block.js
+++ b/src/web/block.js
@@ -76,6 +76,7 @@ async function onMessageFromParent(arg) {
     ...data.classified.recipients.blockWithDomain,
   ];
   const attachments = data.classified.attachments.block;
+  const bodyMatchedWords = data.bodyBlockTargetWords;
   if (recipients.length > 0) {
     for (const recipient of recipients) {
       targets.add(`${recipient.type}: ${recipient.address}`);
@@ -96,6 +97,16 @@ async function onMessageFromParent(arg) {
     const messageAfter = l10n.get("block_messageAfterForAttachments");
     warningContents.push({ targets, messageBefore, messageAfter });
   }
-
+  if (bodyMatchedWords.length > 0) {
+    for (const word of bodyMatchedWords) {
+      targets.add(word);
+    }
+    const messageBefore =
+      data.itemType == Office.MailboxEnums.ItemType.Message
+        ? l10n.get("block_messageBeforeForMailBodies")
+        : l10n.get("block_messageBeforeForAppointmentBodies");
+    const messageAfter = l10n.get("block_messageAfterForBodies");
+    warningContents.push({ targets, messageBefore, messageAfter });
+  }
   showNextWarning();
 }


### PR DESCRIPTION
Add a feature to block to send for unsafe bodies.

## Specification

### Config

Added a "BLOCK" warning type to the unsafe bodies config

```
[SECTION1]
Keywords=社外秘
WarningType=BLOCK
```

We can not specify message (If specified, it is ignored) when the WarningType is Block, that means the message in the block dialog is fixed.

### Block to send

If a body matches the prohibited body keywords, sending mail is blocked with a warning dialog like below.

<img width="529" height="462" alt="image" src="https://github.com/user-attachments/assets/9d9fb8c0-ca0a-4b5f-8586-ac1672c6d326" />


## Test

* Enable count down feature in config dialog
* Specify the following text to the body config.
  ```
  [SECTION1]
  Keywords=社外秘
  WarningType=BLOCK
  ```
* Create a mail to "test@example.com"
* Input "Test" to the subject.
* Input "部外秘" to the body.
* Send the mail
  * [x] Confirm that a warning dialog to block sending is **not** displayed.
  * [x] Confirm that a confirmation dialog is displayed.
* Check all checkbox on the confirmation dialog
* Click the Send button on the confirmation dialog
  * [x] Confirm that the count down dialog is displayed
* Click the cancel button on the count down dialog.
* Create a mail to "test@example.com"
* Input "Test" to the subject.
* Input "社外秘" to the body.
* Send the mail
  * [x] Confirm that a warning dialog to block sending is displayed.
  * [x] Confirm that a confirmation dialog is **not** displayed.
* Click the OK button of the warning dialog
  * [x] Confirm that the mail is **not** sent.

