### PR TITLE
Add clearCcAsync and clearToAsync

### DIFF
--- a/src/web/app.js
+++ b/src/web/app.js
@@ -294,8 +294,8 @@ async function onItemSend(event) {
 
   if (needToConvertToBccOnSend) {
     await Promise.all([
-      OfficeDataAccessHelper.setToAsync([]),
-      OfficeDataAccessHelper.setCcAsync([]),
+      OfficeDataAccessHelper.clearToAsync(),
+      OfficeDataAccessHelper.clearCcAsync(),
       OfficeDataAccessHelper.setBccAsync(data.target.bcc),
     ]);
   }

--- a/src/web/office-data-access-helper.mjs
+++ b/src/web/office-data-access-helper.mjs
@@ -86,6 +86,10 @@ export class OfficeDataAccessHelper {
     });
   }
 
+  static clearCcAsync() {
+    return OfficeDataAccessHelper.setCcAsync([]);
+  }
+
   static getSubjectAsync() {
     return new Promise((resolve, reject) => {
       try {
@@ -199,6 +203,10 @@ export class OfficeDataAccessHelper {
         reject(error);
       }
     });
+  }
+
+  static clearToAsync() {
+    return OfficeDataAccessHelper.setToAsync([]);
   }
 
   static getSessionDataAsync(key) {


### PR DESCRIPTION
Add `clearCcAsync` and `clearToAsync`.

We can use them instead of `setCcAsync([])` and `setToAsync([])`.