### PR TITLE
classifier: do not add unsafe when matching re-warning.

### DIFF
--- a/src/web/attachment-classifier.mjs
+++ b/src/web/attachment-classifier.mjs
@@ -55,7 +55,6 @@ export class AttachmentClassifier {
         trusted.delete(attachment);
       }
       if (rewarningAttachmentMatcher && rewarningAttachmentMatcher.test(attachment.name)) {
-        unsafe.add(attachment);
         rewarning.add(attachment);
         trusted.delete(attachment);
       }

--- a/src/web/recipient-classifier.mjs
+++ b/src/web/recipient-classifier.mjs
@@ -95,10 +95,8 @@ export class RecipientClassifier {
 
         if (this.$rewarningPatternsMatchers.domain.test(classifiedRecipient.domain)) {
           rewarningWithDomain.add(classifiedRecipient);
-          unsafeWithDomain.add(classifiedRecipient);
         } else if (this.$rewarningPatternsMatchers.full.test(classifiedRecipient.address)) {
           rewarning.add(classifiedRecipient);
-          unsafe.add(classifiedRecipient);
         }
       }
     }

--- a/tests/unit/test-recipient-classifier.mjs
+++ b/tests/unit/test-recipient-classifier.mjs
@@ -644,10 +644,6 @@ test_classifyAll.parameters = {
           type: 'Bcc' },
       ],
       unsafeWithDomain: [
-        { recipient: 'bbb@example.org',
-          address: 'bbb@example.org',
-          domain: 'example.org',
-          type: 'Cc' },
         { recipient: 'ccc@example.net',
           address: 'ccc@example.net',
           domain: 'example.net',


### PR DESCRIPTION
Currently, when a target matches a re-warning config, classifier also adds the target to unsafes (warnings).
I have intentionally implemented it because I thought it was better to display a warning before a re-warning.

However, thinking about sometimes users want to use only re-warning, it is better to not to add to the unsafes.