### PR TITLE
Fix a bug that dialog is not updated in low spec environments part 2

### DIFF
--- a/src/web/block.js
+++ b/src/web/block.js
@@ -24,9 +24,11 @@ Office.onReady(() => {
 
   Office.context.ui.addHandlerAsync(
     Office.EventType.DialogParentMessageReceived,
-    onMessageFromParent
+    onMessageFromParent,
+    () => {
+      sendStatusToParent("ready");
+    }
   );
-  sendStatusToParent("ready");
 });
 
 function sendStatusToParent(status) {

--- a/src/web/convert-to-bcc.js
+++ b/src/web/convert-to-bcc.js
@@ -22,9 +22,11 @@ Office.onReady(() => {
 
   Office.context.ui.addHandlerAsync(
     Office.EventType.DialogParentMessageReceived,
-    onMessageFromParent
+    onMessageFromParent,
+    () => {
+      sendStatusToParent("ready");
+    }
   );
-  sendStatusToParent("ready");
 });
 
 function sendStatusToParent(status) {


### PR DESCRIPTION
#136 の修正が BCCへの変換を確認するダイアログと、ブロックする際のダイアログに適用されていなかったため適用


# テスト

以下の環境でテストを実施した。
これは、修正前に事象が発生していたマシンのスペックである。

```
OS Name:                       Microsoft Windows 11 Enterprise N
Processor(s):                  1 Processor(s) Installed.
                               [01]: Intel64 Family 6 Model 79 Stepping 1 GenuineIntel ~2295 Mhz
Total Physical Memory:         4,045 MB
Available Physical Memory:     1,048 MB
```

Outlook on the web、新しいOutlook、クラシックOutlookのそれぞれで以下を確認

* 設定画面を開く
* 「To/CCが一定数以上の場合にBCCに変換する」をONにし、しきい値を1にする
* 注意が必要な本文に以下の記載をする
  ```
  [Blocktest]
  Keywords=社外秘 
  WarningType=BLOCK
  Language=ja
  ```
* 設定画面を閉じる
* 自分自身宛にメールを作成する
* 本文に「社外秘」を指定する
* メールを送信する
  * [x] To/CCをBCCに変換するかどうか尋ねるダイアログが表示されること
  * [x] 本文中に送信を禁止する文言（社外秘）が含まれているため送信をブロックした旨のダイアログが表示されること