### PR TITLE
openDialog: remove needless implementation

### DIFF
--- a/src/web/app.js
+++ b/src/web/app.js
@@ -23,14 +23,14 @@ function sleepAsync(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-async function openDialog({ url, data, asyncContext, promptBeforeOpen, ...params }) {
+async function openDialog({ url, data, asyncContext, ...params }) {
   const asyncResult = await new Promise((resolve) => {
     Office.context.ui.displayDialogAsync(
       url,
       {
         asyncContext,
-        displayInIframe: !promptBeforeOpen,
-        promptBeforeOpen: promptBeforeOpen || false,
+        displayInIframe: true,
+        promptBeforeOpen: false,
         ...params,
       },
       resolve
@@ -46,23 +46,6 @@ async function openDialog({ url, data, asyncContext, promptBeforeOpen, ...params
         );
         await sleepAsync(200);
         return openDialog({ url, data, asyncContext, ...params });
-
-      case 12011:
-        // Maybe we never reach this case because we specify displayInIframe = true at the
-        // first time and then displayDialogAsync does not open a new popup dialog.
-        console.log("failed due to the browser's popup blocker.");
-        if (promptBeforeOpen) {
-          break;
-        }
-        console.log("retrying with prompt.");
-        return openDialog({
-          url,
-          data,
-          asyncContext,
-          ...params,
-          promptBeforeOpen: true,
-        });
-
       default:
         break;
     }


### PR DESCRIPTION
displayDialogAsyncで12011を通るケースは、

* Webブラウザを使用している
* WebブラウザでOutlookのURLのポップアップを許可していない
* `displayDialogAsync`で`displayInIframe`に`false`を指定している
* `displayDialogAsync`で`promptBeforeOpen`に`false`を指定している

という条件を満たすときのみ通るが、現在はそのケースを満たすことがない。
また、一度12011が発生すると、同じコンテキストでもう一度`displayDialogAsync`を実行しても処理が中断されてしまう。
（コードを変更して12011を発生させる状態にして状況を確認すると、エラーになるのではなくて、処理がその場で中断されている様子なので、例外が発生する様子。）

そのため、エラーを捕捉して再実行する処理に意味がないため、削除する。

# テスト

Outlook on the web、新しいOutlook、クラシックOutlookで確認

通常の運用では12011を発生させることはできないので、ダイアログが表示されるケースの一例だけを確認すれば十分である。

* [x] 設定ダイアログが正しく表示されること