### PR TITLE
openDialog: avoid infinite loop

### DIFF
--- a/src/web/app.js
+++ b/src/web/app.js
@@ -23,7 +23,14 @@ function sleepAsync(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-async function openDialog({ url, data, asyncContext, promptBeforeOpen, ...params }) {
+async function openDialog({
+  url,
+  data,
+  asyncContext,
+  promptBeforeOpen,
+  retryCount = 5,
+  ...params
+}) {
   const asyncResult = await new Promise((resolve) => {
     Office.context.ui.displayDialogAsync(
       url,
@@ -44,8 +51,12 @@ async function openDialog({ url, data, asyncContext, promptBeforeOpen, ...params
         console.log(
           "could not open dialog before the previous dialog is not closed completely, so we need to retry it manually."
         );
+        if (retryCount <= 0) {
+          console.log("exceeded maximum retry count.");
+          break;
+        }
         await sleepAsync(200);
-        return openDialog({ url, data, asyncContext, ...params });
+        return openDialog({ url, data, asyncContext, retryCount: retryCount - 1, ...params });
 
       case 12011:
         // Maybe we never reach this case because we specify displayInIframe = true at the

--- a/src/web/app.js
+++ b/src/web/app.js
@@ -49,7 +49,7 @@ async function openDialog({
     switch (asyncResult.error.code) {
       case 12007:
         console.log(
-          "could not open dialog before the previous dialog is not closed completely, so we need to retry it manually."
+          `could not open dialog before the previous dialog is not closed completely, so we need to retry it manually. retryCount: ${retryCount}`
         );
         if (retryCount <= 0) {
           console.log("exceeded maximum retry count.");


### PR DESCRIPTION
前のダイアログが実行中の間（12007が発生する間）、無限ループが発生するため、ループ回数の上限を設けるように修正。

# テスト

ダイアログが可能な限り短い期間で実行されるケースを確認するため（12007のエラーが発生しやすいため）、BCCへの変換ダイアログ -> 送信前確認ダイアログの表示 のタイミングの処理を確認する。

* 設定画面から「To/CCが一定数以上の場合に変換する」をONにし、しきい値に1を指定する
* 新しいメールを作成する
* 送信先に自分自身を指定する
* メールを送信する
* 「To・CCが1件以上指定されています。To・CCをBCCに変換しますか？」のダイアログが表示されるため、「変換しない」をクリックする
* 送信前のFlexConfirmMailの確認ダイアログが表示されるため、キャンセルでキャンセルする
* 上記のメールの送信とキャンセルを10回ほど繰り返す
  * [x] すべてのケースで、すべてのダイアログが正しく表示されること