### PR TITLE
Add try-catch to main event handler

### DIFF
--- a/src/web/app.js
+++ b/src/web/app.js
@@ -353,7 +353,7 @@ async function onAppointmentOrganizer(event) {
       );
     }
   } catch (error) {
-    console.error("Error occurred while creating new appointment compose:", error);
+    console.error("Error occurred while creating new appointment:", error);
   }
   event.completed();
 }

--- a/src/web/app.js
+++ b/src/web/app.js
@@ -292,7 +292,7 @@ async function onItemSend(event) {
     try {
       console.error("Error occurred while sending item:", error);
     } catch {
-      // We should ignore an error occurs on logging.
+      console.error("Error occurred while logging the exception error contents.");
     }
     event.completed({ allowEvent: false });
   }
@@ -321,7 +321,7 @@ async function onNewMessageComposeCreated(event) {
     try {
       console.error("Error occurred while creating new message compose:", error);
     } catch {
-      // We should ignore an error occurs on logging.
+      console.error("Error occurred while logging the exception error contents.");
     }
   }
   event.completed();
@@ -364,7 +364,7 @@ async function onAppointmentOrganizer(event) {
     try {
       console.error("Error occurred while creating new appointment:", error);
     } catch {
-      // We should ignore an error occurs on logging.
+      console.error("Error occurred while logging the exception error contents.");
     }
   }
   event.completed();
@@ -393,7 +393,7 @@ async function onOpenSettingDialog(event) {
     try {
       console.error("Error occurred while opening setting dialog:", error);
     } catch {
-      // We should ignore an error occurs on logging.
+      console.error("Error occurred while logging the exception error contents.");
     }
     event.completed({ allowEvent: false });
   }

--- a/src/web/app.js
+++ b/src/web/app.js
@@ -289,7 +289,11 @@ async function onItemSend(event) {
   try {
     return await onItemSendInner(event);
   } catch (error) {
-    console.error("Error occurred while sending item:", error);
+    try {
+      console.error("Error occurred while sending item:", error);
+    } catch {
+      // We should ignore an error occurs on logging.
+    }
     event.completed({ allowEvent: false });
   }
 }
@@ -314,7 +318,11 @@ async function onNewMessageComposeCreated(event) {
       );
     }
   } catch (error) {
-    console.error("Error occurred while creating new message compose:", error);
+    try {
+      console.error("Error occurred while creating new message compose:", error);
+    } catch {
+      // We should ignore an error occurs on logging.
+    }
   }
   event.completed();
 }
@@ -353,7 +361,11 @@ async function onAppointmentOrganizer(event) {
       );
     }
   } catch (error) {
-    console.error("Error occurred while creating new appointment:", error);
+    try {
+      console.error("Error occurred while creating new appointment:", error);
+    } catch {
+      // We should ignore an error occurs on logging.
+    }
   }
   event.completed();
 }
@@ -378,7 +390,11 @@ async function onOpenSettingDialog(event) {
     console.debug(`onOpensettingDialog: ${status}`);
     updatedAsyncContext.completed({ allowEvent: true });
   } catch (error) {
-    console.error("Error occurred while opening setting dialog:", error);
+    try {
+      console.error("Error occurred while opening setting dialog:", error);
+    } catch {
+      // We should ignore an error occurs on logging.
+    }
     event.completed({ allowEvent: false });
   }
 }

--- a/src/web/app.js
+++ b/src/web/app.js
@@ -23,13 +23,7 @@ function sleepAsync(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-async function openDialog({
-  url,
-  data,
-  asyncContext,
-  retryCount = 5,
-  ...params
-}) {
+async function openDialog({ url, data, asyncContext, retryCount = 5, ...params }) {
   const asyncResult = await new Promise((resolve) => {
     Office.context.ui.displayDialogAsync(
       url,
@@ -234,7 +228,7 @@ async function tryConvertToBcc(data, asyncContext) {
   return false;
 }
 
-async function onItemSend(event) {
+async function onItemSendInner(event) {
   let asyncContext = event;
   const data = await ConfirmData.getCurrentDataAsync(Office.context.mailbox.item.itemType, locale);
   console.debug(data);
@@ -290,81 +284,103 @@ async function onItemSend(event) {
   await OfficeDataAccessHelper.removeOriginalRecipientsSessionDataAsync(data.itemType);
   asyncContext.completed({ allowEvent: true });
 }
+
+async function onItemSend(event) {
+  try {
+    return await onItemSendInner(event);
+  } catch (error) {
+    console.error("Error occurred while sending item:", error);
+    event.completed({ allowEvent: false });
+  }
+}
 window.onItemSend = onItemSend;
 
 async function onNewMessageComposeCreated(event) {
-  const [to, cc, bcc] = await Promise.all([
-    OfficeDataAccessHelper.getToAsync(),
-    OfficeDataAccessHelper.getCcAsync(),
-    OfficeDataAccessHelper.getBccAsync(),
-  ]);
-  if (to.length > 0 || cc.length > 0 || bcc.length > 0) {
-    const originalRecipients = {
-      to,
-      cc,
-      bcc,
-    };
-    await OfficeDataAccessHelper.setOriginalRecipientsSessionDataAsync(
-      Office.context.mailbox.item.itemType,
-      JSON.stringify(originalRecipients)
-    );
+  try {
+    const [to, cc, bcc] = await Promise.all([
+      OfficeDataAccessHelper.getToAsync(),
+      OfficeDataAccessHelper.getCcAsync(),
+      OfficeDataAccessHelper.getBccAsync(),
+    ]);
+    if (to.length > 0 || cc.length > 0 || bcc.length > 0) {
+      const originalRecipients = {
+        to,
+        cc,
+        bcc,
+      };
+      await OfficeDataAccessHelper.setOriginalRecipientsSessionDataAsync(
+        Office.context.mailbox.item.itemType,
+        JSON.stringify(originalRecipients)
+      );
+    }
+  } catch (error) {
+    console.error("Error occurred while creating new message compose:", error);
   }
   event.completed();
 }
 window.onNewMessageComposeCreated = onNewMessageComposeCreated;
 
 async function onAppointmentOrganizer(event) {
-  const [requiredAttendees, optionalAttendees] = await Promise.all([
-    OfficeDataAccessHelper.getRequiredAttendeeAsync(),
-    OfficeDataAccessHelper.getOptionalAttendeeAsync(),
-  ]);
+  try {
+    const [requiredAttendees, optionalAttendees] = await Promise.all([
+      OfficeDataAccessHelper.getRequiredAttendeeAsync(),
+      OfficeDataAccessHelper.getOptionalAttendeeAsync(),
+    ]);
 
-  if (Office.context.platform == Office.PlatformType.PC) {
-    // On classic Outlook, requiredAttendees has a current user even if
-    // this is a new appointment, in that case, subsequent processing
-    // erroneously determines that there are existing attendees.
-    // This function has nothing to do if this is a new appointment
-    // because there is no existing attendees. So return if this is a
-    // new appointment.
-    const id = await OfficeDataAccessHelper.getItemIdAsync();
-    if (!id) {
-      // On classic Outlook, if the id is not defined, this is a new appointment.
-      event.completed();
-      return;
+    if (Office.context.platform == Office.PlatformType.PC) {
+      // On classic Outlook, requiredAttendees has a current user even if
+      // this is a new appointment, in that case, subsequent processing
+      // erroneously determines that there are existing attendees.
+      // This function has nothing to do if this is a new appointment
+      // because there is no existing attendees. So return if this is a
+      // new appointment.
+      const id = await OfficeDataAccessHelper.getItemIdAsync();
+      if (!id) {
+        // On classic Outlook, if the id is not defined, this is a new appointment.
+        event.completed();
+        return;
+      }
     }
-  }
 
-  if (requiredAttendees.length > 0 || optionalAttendees.length > 0) {
-    const originalAttendees = {
-      requiredAttendees,
-      optionalAttendees,
-    };
-    await OfficeDataAccessHelper.setOriginalRecipientsSessionDataAsync(
-      Office.context.mailbox.item.itemType,
-      JSON.stringify(originalAttendees)
-    );
+    if (requiredAttendees.length > 0 || optionalAttendees.length > 0) {
+      const originalAttendees = {
+        requiredAttendees,
+        optionalAttendees,
+      };
+      await OfficeDataAccessHelper.setOriginalRecipientsSessionDataAsync(
+        Office.context.mailbox.item.itemType,
+        JSON.stringify(originalAttendees)
+      );
+    }
+  } catch (error) {
+    console.error("Error occurred while creating new appointment compose:", error);
   }
   event.completed();
 }
 window.onAppointmentOrganizer = onAppointmentOrganizer;
 
 async function onOpenSettingDialog(event) {
-  const policyConfig = await ConfigLoader.loadFileConfig();
-  const userConfig = await ConfigLoader.loadUserConfig();
-  const data = {
-    policy: policyConfig,
-    user: userConfig,
-  };
-  const asyncContext = event;
-  const { status, asyncContext: updatedAsyncContext } = await openDialog({
-    url: window.location.origin + "/setting.html",
-    data,
-    asyncContext,
-    height: Math.min(80, charsToPercentage(70, screen.availHeight)),
-    width: Math.min(80, charsToPercentage(80, screen.availWidth)),
-  });
-  console.debug(`onOpensettingDialog: ${status}`);
-  updatedAsyncContext.completed({ allowEvent: true });
+  try {
+    const policyConfig = await ConfigLoader.loadFileConfig();
+    const userConfig = await ConfigLoader.loadUserConfig();
+    const data = {
+      policy: policyConfig,
+      user: userConfig,
+    };
+    const asyncContext = event;
+    const { status, asyncContext: updatedAsyncContext } = await openDialog({
+      url: window.location.origin + "/setting.html",
+      data,
+      asyncContext,
+      height: Math.min(80, charsToPercentage(70, screen.availHeight)),
+      width: Math.min(80, charsToPercentage(80, screen.availWidth)),
+    });
+    console.debug(`onOpensettingDialog: ${status}`);
+    updatedAsyncContext.completed({ allowEvent: true });
+  } catch (error) {
+    console.error("Error occurred while opening setting dialog:", error);
+    event.completed({ allowEvent: false });
+  }
 }
 window.onOpenSettingDialog = onOpenSettingDialog;
 


### PR DESCRIPTION
各イベントハンドラーで、例外が発生して処理が中断された場合、`event.completed()`が実行されず、常に処理が実行中の扱いとなってしまうため、例外が発生した場合にも`event.completed()`を実行するように変更。

# テスト

* 設定ダイアログを開く
  * [x] 設定ダイアログが開くこと
* 「予定表から送信する場合にも確認する」にチェックを入れる
* 「返信の宛先に今まで含まれていなかったドメインのアドレスが追加された場合警告する」にチェックを入れる
* 設定ダイアログを閉じる
* 既存のメールへの返信を作成し、新しいドメインを追加して送信する
  * [x] FlexConfirmMailの送信前確認ダイアログが表示されること
* 送信ボタンを押す
  * [x] 新しいドメインが追加されている旨の警告が表示されること
* 送信をキャンセルする
* 予定表から新しいイベントを作成し、自分自身に送信する
  * [x] FlexConfirmMailの送信前確認ダイアログが表示されること
* 予定をそのまま送信する
* 作成したイベントを新しいダイアログで開き、送信先に別のドメインのアドレス(例: `a@example.com`)を追加する
* 予定を送信する
  * [x] FlexConfirmMailの送信前確認ダイアログが表示されること
* 送信ボタンを押す
  * [x] 新しいドメインが追加されている旨の警告が表示されること