### PR TITLE
Fix a bug that an exported setting can be wrong

### DIFF
--- a/src/web/setting.js
+++ b/src/web/setting.js
@@ -121,7 +121,7 @@ function serializeTrustedDomains({ mode = Setting.SerializationMode.User }) {
     trustedDomainsString = trustedDomainsString.trim();
   } else {
     trustedDomainsString =
-      `${policyConfig.trustedDomainsString.trim()}\n${trustedDomainsString}`.trim();
+      `${policyConfig.trustedDomainsString.trim()}\n\n${trustedDomainsString.trim()}`.trim();
   }
   return trustedDomainsString;
 }
@@ -162,8 +162,38 @@ function serializeUnsafeDomains({ mode = Setting.SerializationMode.User }) {
   if (mode === Setting.SerializationMode.User) {
     unsafeDomainsString = unsafeDomainsString.trim();
   } else {
+    // We must add [WARNING] just before right (user's) string.
+    // We can ommit [WARNING] section declaration, so when right ommits [WARNING] section declaration,
+    // the right [WARNING] section may be in the wrong section after merged.
+    //
+    // If [WARNING] is not added:
+    //   left:
+    //     [BLOCK]
+    //     a@example.com
+    //   right:
+    //     b@example.com
+    //   merged:
+    //     [BLOCK]
+    //     a@example.com
+    //     b@example.com
+    //
+    // In this case, b@example.com is expected in [WARNING] but in [BLOCK].
+    //
+    // By adding [WARNING]:
+    //   left:
+    //     [BLOCK]
+    //     a@example.com
+    //   right:
+    //     b@example.com
+    //   merged:
+    //     [BLOCK]
+    //     a@example.com
+    //     [WARNING]
+    //     b@example.com
+    //
+    // In this case, b@example.com is in [WARNING] as expected.
     unsafeDomainsString =
-      `${policyConfig.unsafeDomainsString.trim()}\n${unsafeDomainsString}`.trim();
+      `${policyConfig.unsafeDomainsString.trim()}\n\n[${Config.defaultUnsafeDomainsConfigSection}]\n${unsafeDomainsString.trim()}`.trim();
   }
   return unsafeDomainsString;
 }
@@ -204,7 +234,37 @@ function serializeUnsafeFiles({ mode = Setting.SerializationMode.User }) {
   if (mode === Setting.SerializationMode.User) {
     unsafeFilesString = unsafeFilesString.trim();
   } else {
-    unsafeFilesString = `${policyConfig.unsafeFilesString.trim()}\n${unsafeFilesString}`.trim();
+    // We must add [WARNING] just before right (user's) string.
+    // We can ommit [WARNING] section declaration, so when right ommits [WARNING] section declaration,
+    // the right [WARNING] section may be in the wrong section after merged.
+    //
+    // If [WARNING] is not added:
+    //   left:
+    //     [BLOCK]
+    //     a@example.com
+    //   right:
+    //     b@example.com
+    //   merged:
+    //     [BLOCK]
+    //     a@example.com
+    //     b@example.com
+    //
+    // In this case, b@example.com is expected in [WARNING] but in [BLOCK].
+    //
+    // By adding [WARNING]:
+    //   left:
+    //     [BLOCK]
+    //     a@example.com
+    //   right:
+    //     b@example.com
+    //   merged:
+    //     [BLOCK]
+    //     a@example.com
+    //     [WARNING]
+    //     b@example.com
+    //
+    // In this case, b@example.com is in [WARNING] as expected.
+    unsafeFilesString = `${policyConfig.unsafeFilesString.trim()}\n\n[${Config.defaultUnsafeFilesConfigSection}]\n${unsafeFilesString.trim()}`.trim();
   }
   return unsafeFilesString;
 }
@@ -242,7 +302,7 @@ function serializeUnsafeBodies({ mode = Setting.SerializationMode.User }) {
   if (mode === Setting.SerializationMode.User) {
     unsafeBodiesString = unsafeBodiesString.trim();
   } else {
-    unsafeBodiesString = `${policyConfig.unsafeBodiesString.trim()}\n${unsafeBodiesString}`.trim();
+    unsafeBodiesString = `${policyConfig.unsafeBodiesString.trim()}\n\n${unsafeBodiesString.trim()}`.trim();
   }
   return unsafeBodiesString;
 }

--- a/src/web/setting.js
+++ b/src/web/setting.js
@@ -264,7 +264,8 @@ function serializeUnsafeFiles({ mode = Setting.SerializationMode.User }) {
     //     b@example.com
     //
     // In this case, b@example.com is in [WARNING] as expected.
-    unsafeFilesString = `${policyConfig.unsafeFilesString.trim()}\n\n[${Config.defaultUnsafeFilesConfigSection}]\n${unsafeFilesString.trim()}`.trim();
+    unsafeFilesString =
+      `${policyConfig.unsafeFilesString.trim()}\n\n[${Config.defaultUnsafeFilesConfigSection}]\n${unsafeFilesString.trim()}`.trim();
   }
   return unsafeFilesString;
 }
@@ -302,7 +303,8 @@ function serializeUnsafeBodies({ mode = Setting.SerializationMode.User }) {
   if (mode === Setting.SerializationMode.User) {
     unsafeBodiesString = unsafeBodiesString.trim();
   } else {
-    unsafeBodiesString = `${policyConfig.unsafeBodiesString.trim()}\n\n${unsafeBodiesString.trim()}`.trim();
+    unsafeBodiesString =
+      `${policyConfig.unsafeBodiesString.trim()}\n\n${unsafeBodiesString.trim()}`.trim();
   }
   return unsafeBodiesString;
 }


### PR DESCRIPTION
We must add [WARNING] just before right (user's) string. We can ommit [WARNING] section declaration, so when right ommits [WARNING] section declaration, the right [WARNING] section may be in the wrong section after merged.

If [WARNING] is not added:
  left:

```
[BLOCK]
a@example.com
```

  right:

```
b@example.com
```

  merged:

```
[BLOCK]
a@example.com
b@example.com
```

In this case, b@example.com is expected in [WARNING] but in [BLOCK].

By adding [WARNING]:
left:

```
[BLOCK]
a@example.com
```

right:

```
b@example.com
```

merged:

```
[BLOCK]
a@example.com
[WARNING]
b@example.com
```

In this case, b@example.com is in [WARNING] as expected.

Also fixed output format.

## Test

* コンテンツフォルダーのconfigsフォルダーに本リポジトリの「`tests\run-test-server\configs`」の内容を配置する
* 設定ダイアログを開く
* 「設定をリセット」するボタンを押す
* 設定を任意に変更する
* 「このアドインについて」タブを開く
* 「現在の設定をファイルとしてダウンロードする」ボタンを押す
* [x] 以下のファイルがダウンロードされること
  * Common.txt
    * [x] 一般設定 ＋「注意が必要なパターンに該当する宛先を「社内ではない」ものとして扱う」のすべての設定が出力されること
    * [x] FixedParametersプロパティが含まれていること 
  * TrustedDomains.txt
    * [x] 社内ドメイン・アドレスの内容が出力されること
    * [x] 画面で設定した内容+`configs\TrustedDomains.txt`の内容であること 
  * UnsafeBodies.txt
    * [x] 注意が必要な本文の内容が出力されること
    * [x] 画面で設定した内容+`configs\UnsafeBodies.txt`の内容であること 
  * UnsafeDomains.txt
    * [x] 注意が必要なドメイン・アドレスの内容が出力されること
    * [x] 画面で設定した内容+`configs\UnsafeDomains.txt`の内容であること
    * [x] 画面で設定した内容の直前に`[WARNING]`が入っていること
  * UnsafeFiles.txt
    * [x] 注意が必要なファイル名の内容が出力されること
    * [x] 画面で設定した内容+`configs\UnsafeFiles.txt`の内容であること
    * [x] 画面で設定した内容の直前に`[WARNING]`が入っていること