### PR TITLE
locale: enable to specify html format messages

### DIFF
--- a/src/web/confirm.html
+++ b/src/web/confirm.html
@@ -11,7 +11,6 @@ Copyright (c) 2025 ClearCode Inc.
 <head>
     <title>Confirmation</title>
     <meta http-equiv="X-UA-Compatible" content="IE=Edge">
-    <script src="lib/dompurify/purify.min.js" type="module"></script>
     <script src="lib/fluentui/web-components/web-components.min.js" type="module"></script>
     <script src="https://appsforoffice.microsoft.com/lib/1/hosted/office.js" type="text/javascript"></script>
     <link href="dialog.css" rel="stylesheet">

--- a/src/web/confirm.js
+++ b/src/web/confirm.js
@@ -15,6 +15,7 @@ import { UnsafeAddressesReconfirmation } from "./unsafe-addresses-reconfirmation
 import { UnsafeFilesReconfirmation } from "./unsafe-files-reconfirmation.mjs";
 import { UnsafeBodiesConfirmation } from "./unsafe-bodies-confirmation.mjs";
 import * as Dialog from "./dialog.mjs";
+import DOMPurify from "dompurify";
 
 let l10n;
 let safeBccConfirmation;

--- a/src/web/l10n.mjs
+++ b/src/web/l10n.mjs
@@ -5,6 +5,8 @@
 */
 "use strict";
 
+import DOMPurify from "dompurify";
+
 export class L10n {
   static cache = {};
   static requests = {};
@@ -92,7 +94,14 @@ export class L10n {
   }
 
   get(key, params = {}) {
-    let message =
+    const { message } = this.getWithType(key, params);
+    return message;
+  }
+
+  getWithType(key, params = {}) {
+    let type = "string";
+    let message = "";
+    const messageEntry =
       key in this.locale
         ? this.locale[key]
         : key in this.fallbackLocale
@@ -100,20 +109,34 @@ export class L10n {
           : key in this.defaultLocale
             ? this.defaultLocale[key]
             : null;
+    if (messageEntry === null) {
+      return { message: key, type };
+    }
+    if (typeof messageEntry === "string") {
+      message = messageEntry;
+    } else {
+      type = messageEntry.type || type;
+      message = messageEntry.message || key;
+    }
     if (message === null) {
-      return key;
+      return { message: key, type };
     }
     if (params) {
       for (const [placeholder, value] of Object.entries(params)) {
         message = message.replace("${" + placeholder + "}", value || "");
       }
     }
-    return message;
+    return { message, type };
   }
 
   translateAll() {
     for (const element of document.querySelectorAll("[data-l10n-text-content]")) {
-      element.textContent = this.get(element.dataset.l10nTextContent);
+      const { message, type } = this.getWithType(element.dataset.l10nTextContent);
+      if (type === "html") {
+        element.innerHTML = DOMPurify.sanitize(message);
+      } else {
+        element.textContent = message;
+      }
     }
   }
 }

--- a/tests/fixtures/locales/en.json
+++ b/tests/fixtures/locales/en.json
@@ -3,5 +3,6 @@
   "blankMessage": "Blank message",
   "messageWithPlaceholders": "Message with placeholders: ${one}, ${two}",
   "missingFallbackMessage": "Message defined in fallback locales",
-  "missingMessage": "Message not defined in non-default locales"
+  "missingMessage": "Message not defined in non-default locales",
+  "htmlMessage": { "message": "<strong>HTML format message</strong>" , "type": "html" }
 }

--- a/tests/fixtures/locales/ja-JP.json
+++ b/tests/fixtures/locales/ja-JP.json
@@ -4,5 +4,6 @@
   "messageWithPlaceholders": "JP：プレースホルダーを含むメッセージ：${one}, ${two}, ${three}",
   "_missingFallbackMessage": "JP：フォールバック先で定義されているメッセージ",
   "_missingMessage": "JP：未定義のメッセージ",
-  "customOverrideMessage": "JP：カスタムロケールに上書きされるメッセージ"
+  "customOverrideMessage": "JP：カスタムロケールに上書きされるメッセージ",
+  "htmlMessage": { "message": "JP：<strong>HTML形式のメッセージ</strong>" , "type": "html" }
 }

--- a/tests/fixtures/locales/ja.json
+++ b/tests/fixtures/locales/ja.json
@@ -3,5 +3,6 @@
   "blankMessage": "空のメッセージ",
   "messageWithPlaceholders": "プレースホルダーを含むメッセージ：${one}, ${two}",
   "missingFallbackMessage": "フォールバック先で定義されているメッセージ",
-  "_missingMessage": "未定義のメッセージ"
+  "_missingMessage": "未定義のメッセージ",
+  "htmlMessage": { "message": "<strong>HTML形式のメッセージ</strong>" , "type": "html" }
 }

--- a/tests/unit/test-l10n.mjs
+++ b/tests/unit/test-l10n.mjs
@@ -43,6 +43,11 @@ test_get.parameters = {
     key: "missingFallbackMessage",
     expected: "フォールバック先で定義されているメッセージ",
   },
+  html: {
+    language: "ja-JP",
+    key: "htmlMessage",
+    expected: "JP：<strong>HTML形式のメッセージ</strong>",
+  },
   customLocale: {
     language: "ja-JP",
     key: "customOverrideMessage",
@@ -72,4 +77,65 @@ test_get.parameters = {
 export async function test_get({ language, key, params, expected }) {
   const l10n = await prepare(language);
   is(expected, l10n.get(key, params || null));
+}
+
+test_getWithType.parameters = {
+  effective: {
+    language: "ja-JP",
+    key: "effectiveMessage",
+    expected: {"message": "JP：意味ある内容を含むメッセージ", "type": "string"},
+  },
+  blank: {
+    language: "ja-JP",
+    key: "blankMessage",
+    expected: {"message": "", "type": "string"},
+  },
+  withPlaceholders: {
+    language: "ja-JP",
+    key: "messageWithPlaceholders",
+    params: {
+      one: "One",
+      two: "Two",
+    },
+    expected: {"message": "JP：プレースホルダーを含むメッセージ：One, Two, ${three}", "type": "string"},
+  },
+  fallbackToGeneralLocale: {
+    language: "ja-JP",
+    key: "missingFallbackMessage",
+    expected: {"message": "フォールバック先で定義されているメッセージ", "type": "string"},
+  },
+  html: {
+    language: "ja-JP",
+    key: "htmlMessage",
+    expected: {"message": "JP：<strong>HTML形式のメッセージ</strong>", "type": "html"},
+  },
+  customLocale: {
+    language: "ja-JP",
+    key: "customOverrideMessage",
+    expected: {"message": "JP：カスタムロケールの上書きメッセージ", "type": "string"},
+  },
+  customLocaleOverride: {
+    language: "ja-JP",
+    key: "customMessage",
+    expected: {"message": "JP：カスタムロケールのメッセージ", "type": "string"},
+  },
+  fallbackToDefaultLocale: {
+    language: "ja-JP",
+    key: "missingMessage",
+    expected: {"message": "Message not defined in non-default locales", "type": "string"},
+  },
+  differentLocale: {
+    language: "en",
+    key: "effectiveMessage",
+    expected: {"message": "Message with effective content", "type": "string"},
+  },
+  undefinedMessage: {
+    language: "en",
+    key: "undefinedMessage",
+    expected: {"message": "undefinedMessage", "type": "string"},
+  },
+};
+export async function test_getWithType({ language, key, params, expected }) {
+  const l10n = await prepare(language);
+  is(expected, l10n.getWithType(key, params || null));
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -75,10 +75,6 @@ module.exports = async (env, options) => {
             from: "node_modules/@fluentui/web-components/dist/web-components.min.js",
             to: "lib/fluentui/web-components/web-components.min.js",
           },
-          {
-            from: "node_modules/dompurify/dist/purify.min.js",
-            to: "lib/dompurify/purify.min.js",
-          },
         ],
       }),
       new HtmlWebpackPlugin({


### PR DESCRIPTION
localeでhtml形式のメッセージを指定可能とする。
まずは`data-l10n-text-content`で指定されたもののみを対象とする。

また、今回i18n.mjsでdompurifyを使うことになったが、JavaScript側で

import DOMPurify from "dompurify";

とすれば、webpackがdompurifyをバンドルしてくれることがわかったので、従来`<script src="lib/dompurify/purify.min.js" type="module"></script>`としていた部分は削除して、importするようにした。

# テスト

* アドインのWEBサーバーを動作させる（リポジトリ上で実行する場合は、`cd tests\run-test-server` と `run-test-server.bat`を実行する。）
* アドインのWEBサーバーのコンテンツフォルダー(上記の手順でWEBサーバーを動作させた場合は`run-test-server\web`)に`custom-locales`を作成する。
* 以下の内容の`custom-locales\ja.json`を作成する
    ```
    {
      "setting_requireCheckBody": {"message": "<strong>メール本文の確認を求める</strong>", "type": "html" }
    }
    ```
* OutlookからFlexConfirmMailの設定画面を開く
* 一般タブを開く
  *  [x] 「メール本文の確認を求める」が強調表示されていること
<img width="1034" height="244" alt="image" src="https://github.com/user-attachments/assets/8ddd384b-c9c7-49c9-ab3b-06acaa22e693" />
