### PR TITLE
Add custom css support for the confirm dialog

### DIFF
--- a/src/web/confirm.js
+++ b/src/web/confirm.js
@@ -53,6 +53,23 @@ Office.onReady(() => {
   );
 });
 
+async function loadCustomCssIfExists() {
+  try {
+    const path = "custom-css/confirm.css";
+    const res = await fetch(path, { method: "HEAD" });
+    if (!res.ok) {
+      console.debug("No custom CSS found, skipping loading custom-css/confirm.css");
+      return;
+    }
+    const link = document.createElement("link");
+    link.rel = "stylesheet";
+    link.href = path;
+    document.head.appendChild(link);
+  } catch (error) {
+    console.debug("Failed to load custom CSS.", error);
+  }
+}
+
 let counter = 0;
 function generateTempId() {
   return `fcm_temp_${counter++}_${Date.now()}`;
@@ -190,6 +207,7 @@ function appendCheckbox({ container, id, label, warning, emphasize }) {
 async function onMessageFromParent(arg) {
   const receivedData = JSON.parse(arg.message);
   console.log(receivedData);
+  await loadCustomCssIfExists();
   const data = new ConfirmData(receivedData);
   await Promise.all([
     l10n.ready,

--- a/tests/run-test-server/custom-css/confirm.css
+++ b/tests/run-test-server/custom-css/confirm.css
@@ -1,0 +1,15 @@
+#untrusted-domains-card {
+  background-color: lemonchiffon;
+  border-color: red;
+}
+
+#untrusted-domains-card .warning-icon {
+  color: red; 
+  font-size: 48px;
+}
+
+#untrusted-domains-card strong {
+  font-size: 36px;
+  font-weight: bold;
+  color: red;
+}

--- a/tests/run-test-server/custom-locales/ja.json
+++ b/tests/run-test-server/custom-locales/ja.json
@@ -1,0 +1,3 @@
+{
+  "confirmation_untrustedCaption": {"message": "外部ドメインのメールアドレス<br/><span class=\"warning-icon\">⚠</span><u><strong>社外の宛先</strong>が指定されています！<strong>再確認</strong>してください！</u>", "type": "html"}
+}


### PR DESCRIPTION
送信前確認画面でのカスタムCSSのサポートを追加。

`{コンテンツフォルダー}/custom-css/confirm.css`

にカスタムCSSを設置することで、送信前確認画面のスタイルを自由に変更可能。

## Test

* マニフェストをサイドロードする
* アドインのWEBサーバーを動作させる（リポジトリ上で実行する場合は、`cd tests\run-test-server` と `run-test-server.bat`を実行する。）
* Outlookを起動する
* 以下のアドレス宛のメールを作成する
  * test@external.example.com
  * test@external2.example.com
* 以下の件名を指定する
  * テスト
* 以下の本文を指定する
  * テスト
* メールを送信する
  * [x] 送信前確認画面が表示されること
  * [x] 「外部ドメインのメールアドレス」のカードのスタイルが他のカードと同じであること
* 「キャンセル」ボタンで送信をキャンセルする
* アドインのWEBサーバーのコンテンツフォルダー(上記の手順でWEBサーバーを動作させた場合は`run-test-server\web`)に`tests\run-test-server\custom-locales`フォルダーと`tests\run-test-server\custom-css`フォルダーをコピーする。
* Outlookを再起動する
* 以下のアドレス宛のメールを作成する
  * test@external.example.com
  * test@external2.example.com
* 以下の件名を指定する
  * テスト
* 以下の本文を指定する
  * テスト
* メールを送信する
  * [x] 送信前確認画面が表示されること
  * [x] 「外部ドメインのメールアドレス」のカードのスタイルおよび文言が以下の画像のように変更されていること
* 「キャンセル」ボタンで送信をキャンセルする

<img width="930" height="598" alt="image" src="https://github.com/user-attachments/assets/a143af75-4a26-4be2-b131-20b9f3394cce" />
