### PR TITLE
Adjust list spacing in confirmation dialog.

### DIFF
--- a/src/web/confirm.css
+++ b/src/web/confirm.css
@@ -29,6 +29,11 @@ fluent-card {
   height: auto;
 }
 
+fluent-card h4 {
+  margin-top: 5px;
+  margin-bottom: 5px;
+}
+
 #mail-subject-card fluent-checkbox::part(label) {
   font-size: initial;
 }


### PR DESCRIPTION
確認ダイアログのチェックボックスのリストの間隔、特にグループ分けしたときのドメイン表示部分の間隔を微調整。
若干短くした。

<img width="936" height="335" alt="image" src="https://github.com/user-attachments/assets/1f2ff1fe-62b1-4517-9c73-aa8071b3f8a7" />

変更前

<img width="936" height="286" alt="image" src="https://github.com/user-attachments/assets/6802dc25-726b-4cd6-b2d6-618a3c6b4b0d" />

変更後

