### PR TITLE
Add a config parameter "ConfirmationDialogCardsOrder"

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -104,5 +104,8 @@
   "setting_requireCheckSubject": "Require check the subject",
   "setting_requireCheckBody": "Require to check the message body",
   "setting_configBlockDistributionLists":	"Block sending if unexpanded distribution lists or contact groups are included",
-  "setting_configEmphasizeUntrustedToCc": "Emphasize external domains in To/Cc fields"
+  "setting_configEmphasizeUntrustedToCc": "Emphasize external domains in To/Cc fields",
+  "setting_configConfirmationDialogCardsOrder": "Confirmation Dialog Items Order",
+  "setting_moveUp": "Move Up",
+  "setting_moveDown": "Move Down"
 }

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -104,5 +104,8 @@
   "setting_requireCheckSubject": "件名の確認を求める",
   "setting_requireCheckBody": "メール本文の確認を求める",
   "setting_configBlockDistributionLists": "未展開の配布リスト、連絡グループが含まれる場合、送信を禁止する",
-  "setting_configEmphasizeUntrustedToCc": "社外ドメインのTo・CCを強調表示する"
+  "setting_configEmphasizeUntrustedToCc": "社外ドメインのTo・CCを強調表示する",
+  "setting_configConfirmationDialogCardsOrder": "確認ダイアログの確認項目の表示順",
+  "setting_moveUp": "上へ移動",
+  "setting_moveDown": "下へ移動"
 }

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -105,7 +105,7 @@
   "setting_requireCheckBody": "メール本文の確認を求める",
   "setting_configBlockDistributionLists": "未展開の配布リスト、連絡グループが含まれる場合、送信を禁止する",
   "setting_configEmphasizeUntrustedToCc": "社外ドメインのTo・CCを強調表示する",
-  "setting_configConfirmationDialogCardsOrder": "確認ダイアログの確認項目の表示順",
+  "setting_configConfirmationDialogCardsOrder": "確認ダイアログの確認項目の表示順設定",
   "setting_moveUp": "上へ移動",
   "setting_moveDown": "下へ移動"
 }

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -104,5 +104,8 @@
   "setting_requireCheckSubject": "要求确认主题",
   "setting_requireCheckBody": "要求确认电子邮件的文本",
   "setting_configBlockDistributionLists":	"如果包含未展开的分发列表、联系人组，则禁止发送",
-  "setting_configEmphasizeUntrustedToCc": "将外部域名的收件人（To）・抄送（CC）高亮显示"
+  "setting_configEmphasizeUntrustedToCc": "将外部域名的收件人（To）・抄送（CC）高亮显示",
+  "setting_configConfirmationDialogCardsOrder": "Confirmation Dialog Items Order",
+  "setting_moveUp": "上移",
+  "setting_moveDown": "下移"
 }

--- a/src/web/config.mjs
+++ b/src/web/config.mjs
@@ -17,6 +17,8 @@ export class Config {
   unsafeFilesString = "";
   unsafeBodiesString = "";
 
+  static CARD_DEFAULT_ORDER = ["TrustedDomains", "UntrustedDomains", "Subject", "Body", "Misc"];
+
   constructor({
     common,
     trustedDomains,
@@ -220,7 +222,7 @@ export class Config {
         ConvertToBccThreshold: 2,
         BlockDistributionLists: true,
         EmphasizeUntrustedToCc: false,
-        ConfirmationDialogCardsOrder: [],
+        ConfirmationDialogCardsOrder: [...Config.CARD_DEFAULT_ORDER],
         FixedParameters: [],
       },
       trustedDomains: [],

--- a/src/web/config.mjs
+++ b/src/web/config.mjs
@@ -144,7 +144,7 @@ export class Config {
     }
     let commonString = "";
     for (const [key, value] of Object.entries(this.common)) {
-      if (key === "FixedParameters") {
+      if (Config.commonParamDefs[key] === "commaSeparatedValues") {
         if (value.length > 0) {
           commonString += `${key} = ${value.join(",")}\n`;
         }
@@ -177,6 +177,7 @@ export class Config {
     ConvertToBccThreshold: "number",
     BlockDistributionLists: "boolean",
     EmphasizeUntrustedToCc: "boolean",
+    ConfirmationDialogCardsOrder: "commaSeparatedValues",
     FixedParameters: "commaSeparatedValues",
   };
   static unsafeBodiesParamDefs = {
@@ -213,6 +214,7 @@ export class Config {
         ConvertToBccThreshold: 2,
         BlockDistributionLists: true,
         EmphasizeUntrustedToCc: false,
+        ConfirmationDialogCardsOrder: [],
         FixedParameters: [],
       },
       trustedDomains: [],

--- a/src/web/config.mjs
+++ b/src/web/config.mjs
@@ -57,10 +57,16 @@ export class Config {
           this.common[paramName] = other.common[paramName];
           break;
         case "commaSeparatedValues": {
-          const thisParamValue = this.common[paramName] ?? [];
-          const otherParamValue = other.common[paramName] ?? [];
-          const newParamValueSet = new Set([...thisParamValue, ...otherParamValue]);
-          this.common[paramName] = [...newParamValueSet];
+          if (paramName === "FixedParameters") {
+            // For FixedParameters, the merged value is a union of both values, and duplicates are removed.
+            const thisParamValue = this.common[paramName] ?? [];
+            const otherParamValue = other.common[paramName] ?? [];
+            const newParamValueSet = new Set([...thisParamValue, ...otherParamValue]);
+            this.common[paramName] = [...newParamValueSet];
+          } else if (paramName === "ConfirmationDialogCardsOrder") {
+            // For ConfirmationDialogCardsOrder, the merged value is the value of other if it's not empty, otherwise the value of this.
+            this.common[paramName] = other.common[paramName];
+          }
           break;
         }
         default:

--- a/src/web/confirm.js
+++ b/src/web/confirm.js
@@ -14,6 +14,7 @@ import { UnsafeDomainsReconfirmation } from "./unsafe-domains-reconfirmation.mjs
 import { UnsafeAddressesReconfirmation } from "./unsafe-addresses-reconfirmation.mjs";
 import { UnsafeFilesReconfirmation } from "./unsafe-files-reconfirmation.mjs";
 import { UnsafeBodiesConfirmation } from "./unsafe-bodies-confirmation.mjs";
+import { Config } from "./config.mjs";
 import * as Dialog from "./dialog.mjs";
 import DOMPurify from "dompurify";
 
@@ -33,7 +34,6 @@ const CARD_ID_MAP = {
   Body: "mail-body-card",
   Misc: "misc-card",
 };
-const DEFAULT_ORDER = ["TrustedDomains", "UntrustedDomains", "Subject", "Body", "Misc"];
 
 Office.onReady(() => {
   if (window !== window.parent) {
@@ -206,7 +206,7 @@ function reorderCards(confirmationDialogCardsOrder) {
     return;
   }
   const specified = confirmationDialogCardsOrder.filter((_) => _ in CARD_ID_MAP);
-  const rest = DEFAULT_ORDER.filter((_) => !specified.includes(_));
+  const rest = Config.CARD_DEFAULT_ORDER.filter((_) => !specified.includes(_));
   const order = [...specified, ...rest];
 
   for (const key of order) {

--- a/src/web/confirm.js
+++ b/src/web/confirm.js
@@ -35,7 +35,6 @@ const CARD_ID_MAP = {
 };
 const DEFAULT_ORDER = ["TrustedDomains", "UntrustedDomains", "Subject", "Body", "Misc"];
 
-
 Office.onReady(() => {
   if (window !== window.parent) {
     // Inframe mode
@@ -202,12 +201,12 @@ function reorderCards(confirmationDialogCardsOrder) {
     return;
   }
 
-  const container = document.querySelector('.cards');
+  const container = document.querySelector(".cards");
   if (!container) {
     return;
   }
-  const specified = confirmationDialogCardsOrder.filter(k => k in CARD_ID_MAP);
-  const rest = DEFAULT_ORDER.filter(k => !specified.includes(k));
+  const specified = confirmationDialogCardsOrder.filter((_) => _ in CARD_ID_MAP);
+  const rest = DEFAULT_ORDER.filter((_) => !specified.includes(_));
   const order = [...specified, ...rest];
 
   for (const key of order) {

--- a/src/web/confirm.js
+++ b/src/web/confirm.js
@@ -26,6 +26,16 @@ let unsafeAddressesReconfirmation;
 let unsafeFilesReconfirmation;
 let unsafeBodiesConfirmation;
 
+const CARD_ID_MAP = {
+  UntrustedDomains: "untrusted-domains-card",
+  TrustedDomains: "trusted-domains-card",
+  Subject: "mail-subject-card",
+  Body: "mail-body-card",
+  Misc: "misc-card",
+};
+const DEFAULT_ORDER = ["TrustedDomains", "UntrustedDomains", "Subject", "Body", "Misc"];
+
+
 Office.onReady(() => {
   if (window !== window.parent) {
     // Inframe mode
@@ -187,6 +197,27 @@ function appendCheckbox({ container, id, label, warning, emphasize }) {
   container.appendChild(checkbox);
 }
 
+function reorderCards(confirmationDialogCardsOrder) {
+  if (!confirmationDialogCardsOrder?.length) {
+    return;
+  }
+
+  const container = document.querySelector('.cards');
+  if (!container) {
+    return;
+  }
+  const specified = confirmationDialogCardsOrder.filter(k => k in CARD_ID_MAP);
+  const rest = DEFAULT_ORDER.filter(k => !specified.includes(k));
+  const order = [...specified, ...rest];
+
+  for (const key of order) {
+    const card = document.getElementById(CARD_ID_MAP[key]);
+    if (card) {
+      container.appendChild(card);
+    }
+  }
+}
+
 async function onMessageFromParent(arg) {
   const receivedData = JSON.parse(arg.message);
   console.log(receivedData);
@@ -314,5 +345,6 @@ async function onMessageFromParent(arg) {
       reconfirmation.appendContent(content);
     }
   }
+  reorderCards(data.config.common.ConfirmationDialogCardsOrder);
   Dialog.resizeToContent();
 }

--- a/src/web/setting.css
+++ b/src/web/setting.css
@@ -48,6 +48,16 @@ fluent-tabs {
   margin-left: 10px;
 }
 
+.button-container.card-order-buttons {
+  margin-top: 10px;
+  text-align: left;
+}
+
+.button-container.card-order-buttons fluent-button {
+  margin-left: 0;
+  margin-right: 10px;
+}
+
 fluent-text-area {
   height: 100%;
   width: 100%;

--- a/src/web/setting.html
+++ b/src/web/setting.html
@@ -51,6 +51,23 @@ Copyright (c) 2025 ClearCode Inc.
                         id="safeNewDomainsEnabled" data-l10n-text-content="setting_configSafeNewDomainsEnabled"></fluent-checkbox><br />
                 </fluent-card>
                 <fluent-card>
+                    <strong data-l10n-text-content="setting_configConfirmationDialogCardsOrder"></strong>
+                    <fluent-divider></fluent-divider>
+                    <div id="card-order-settings">
+                        <fluent-listbox id="card-order-list" size="5">
+                            <fluent-option value="TrustedDomains" data-l10n-text-content="confirmation_trustedCaption"></fluent-option>
+                            <fluent-option value="UntrustedDomains" data-l10n-text-content="confirmation_untrustedCaption" ></fluent-option>
+                            <fluent-option value="Subject" data-l10n-text-content="confirmation_subjectCaption"></fluent-option>
+                            <fluent-option value="Body" data-l10n-text-content="confirmation_bodyCaption"></fluent-option>
+                            <fluent-option value="Misc" data-l10n-text-content="confirmation_miscCaption"></fluent-option>
+                        </fluent-listbox>
+                        <div id="card-order-buttons" class="button-container card-order-buttons">
+                            <fluent-button id="moveUpButton" onclick="onMoveUpCard()" data-l10n-text-content="setting_moveUp"></fluent-button>
+                            <fluent-button id="moveDownButton" onclick="onMoveDownCard()" data-l10n-text-content="setting_moveDown"></fluent-button>
+                        </div>
+                    </div>
+                </fluent-card>
+                <fluent-card>
                     <strong data-l10n-text-content="setting_configMisc"></strong>
                     <fluent-divider></fluent-divider>
                     <fluent-checkbox id="requireCheckSubject" data-l10n-text-content="setting_requireCheckSubject"></fluent-checkbox><br />

--- a/src/web/setting.html
+++ b/src/web/setting.html
@@ -54,7 +54,7 @@ Copyright (c) 2025 ClearCode Inc.
                     <strong data-l10n-text-content="setting_configConfirmationDialogCardsOrder"></strong>
                     <fluent-divider></fluent-divider>
                     <div id="card-order-settings">
-                        <fluent-listbox id="card-order-list" size="5">
+                        <fluent-listbox id="cardOrderList" size="5">
                             <fluent-option value="TrustedDomains" data-l10n-text-content="confirmation_trustedCaption"></fluent-option>
                             <fluent-option value="UntrustedDomains" data-l10n-text-content="confirmation_untrustedCaption" ></fluent-option>
                             <fluent-option value="Subject" data-l10n-text-content="confirmation_subjectCaption"></fluent-option>

--- a/src/web/setting.js
+++ b/src/web/setting.js
@@ -334,7 +334,7 @@ function swapOptionContents(a, b) {
 }
 
 function reorderListbox(order) {
-  const listbox = document.getElementById("card-order-list");
+  const listbox = document.getElementById("cardOrderList");
   const options = [...listbox.querySelectorAll("fluent-option")];
 
   order.forEach((value, i) => {
@@ -425,15 +425,15 @@ function updateDialogSetting(policy, user) {
   document.getElementById("emphasizeUntrustedToCc").disabled =
     fixedParametersSet.has("EmphasizeUntrustedToCc");
   reorderListbox(common.ConfirmationDialogCardsOrder ?? []);
-  document.getElementById("card-order-list").disabled = fixedParametersSet.has(
-    "ConfirmationDialogCardsOrder"
-  );
-  document.getElementById("moveUpButton").disabled = fixedParametersSet.has(
-    "ConfirmationDialogCardsOrder"
-  );
-  document.getElementById("moveDownButton").disabled = fixedParametersSet.has(
-    "ConfirmationDialogCardsOrder"
-  );
+  if (fixedParametersSet.has("ConfirmationDialogCardsOrder")) {
+    const listbox = document.getElementById("cardOrderList");
+    listbox.disabled = true;
+    listbox.querySelectorAll("fluent-option").forEach((opt) => {
+      opt.disabled = true;
+    });
+    document.getElementById("moveUpButton").disabled = true;
+    document.getElementById("moveDownButton").disabled = true;
+  }
 }
 
 function sendStatusToParent(status) {
@@ -487,7 +487,7 @@ function serializeCommonConfigs({ mode = Setting.SerializationMode.User }) {
   const blockDistributionLists = document.getElementById("blockDistributionLists").checked;
   const emphasizeUntrustedToCc = document.getElementById("emphasizeUntrustedToCc").checked;
   const confirmationDialogCardsOrder = [
-    ...document.querySelectorAll("#card-order-list fluent-option"),
+    ...document.querySelectorAll("#cardOrderList fluent-option"),
   ]
     .map((opt) => opt.value)
     .join(",");
@@ -646,7 +646,7 @@ window.onDownload = () => {
 };
 
 function moveCard(direction) {
-  const listbox = document.getElementById("card-order-list");
+  const listbox = document.getElementById("cardOrderList");
   const options = [...listbox.querySelectorAll("fluent-option")];
   const idx = options.findIndex((_) => _.getAttribute("aria-selected") === "true");
   const targetIdx = idx + direction;

--- a/src/web/setting.js
+++ b/src/web/setting.js
@@ -322,6 +322,28 @@ async function onMessageFromParent(arg) {
   updateDialogSetting(configs.policy, configs.user);
 }
 
+function swapOptionContents(a, b) {
+  // Swapping DOM elements doesn't update the listbox's internal state,
+  // so swap the contents instead.
+  const tmpValue = a.value;
+  const tmpText = a.textContent;
+  a.value = b.value;
+  a.textContent = b.textContent;
+  b.value = tmpValue;
+  b.textContent = tmpText;
+}
+
+function reorderListbox(order) {
+  const listbox = document.getElementById("card-order-list");
+  const options = [...listbox.querySelectorAll("fluent-option")];
+
+  order.forEach((value, i) => {
+    const sourceIdx = options.findIndex((opt) => opt.value === value);
+    if (sourceIdx < 0 || sourceIdx === i) return;
+    swapOptionContents(options[i], options[sourceIdx]);
+  });
+}
+
 function updateDialogSetting(policy, user) {
   policyConfig = policyConfig.merge(policy);
   userConfig = userConfig.merge(user);
@@ -402,6 +424,16 @@ function updateDialogSetting(policy, user) {
   document.getElementById("emphasizeUntrustedToCc").checked = common.EmphasizeUntrustedToCc;
   document.getElementById("emphasizeUntrustedToCc").disabled =
     fixedParametersSet.has("EmphasizeUntrustedToCc");
+  reorderListbox(common.ConfirmationDialogCardsOrder ?? []);
+  document.getElementById("card-order-list").disabled = fixedParametersSet.has(
+    "ConfirmationDialogCardsOrder"
+  );
+  document.getElementById("moveUpButton").disabled = fixedParametersSet.has(
+    "ConfirmationDialogCardsOrder"
+  );
+  document.getElementById("moveDownButton").disabled = fixedParametersSet.has(
+    "ConfirmationDialogCardsOrder"
+  );
 }
 
 function sendStatusToParent(status) {
@@ -454,6 +486,11 @@ function serializeCommonConfigs({ mode = Setting.SerializationMode.User }) {
   const convertToBccThreshold = document.getElementById("convertToBccThreshold").value;
   const blockDistributionLists = document.getElementById("blockDistributionLists").checked;
   const emphasizeUntrustedToCc = document.getElementById("emphasizeUntrustedToCc").checked;
+  const confirmationDialogCardsOrder = [
+    ...document.querySelectorAll("#card-order-list fluent-option"),
+  ]
+    .map((opt) => opt.value)
+    .join(",");
   let commonConfigString = "";
   commonConfigString += serializeCommonConfig(mode, "CountEnabled", countEnabled);
   commonConfigString += serializeCommonConfig(mode, "CountSeconds", countSeconds);
@@ -498,6 +535,16 @@ function serializeCommonConfigs({ mode = Setting.SerializationMode.User }) {
     mode,
     "EmphasizeUntrustedToCc",
     emphasizeUntrustedToCc
+  );
+  commonConfigString += serializeCommonConfig(
+    mode,
+    "SafeBccReconfirmationThreshold",
+    safeBccReconfirmationThreshold
+  );
+  commonConfigString += serializeCommonConfig(
+    mode,
+    "ConfirmationDialogCardsOrder",
+    confirmationDialogCardsOrder
   );
   // FixedParameters is for policy setting.
   // Do not serialize FixedParameters for user setting.
@@ -557,7 +604,6 @@ window.onDownload = () => {
   const unsafeDomainsString = serializeUnsafeDomains({ mode });
   const unsafeFilesString = serializeUnsafeFiles({ mode });
   const unsafeBodiesString = serializeUnsafeBodies({ mode });
-
   const targets = [
     {
       name: "Common.txt",
@@ -598,3 +644,17 @@ window.onDownload = () => {
     console.log(`File downloaded successfully: ${name}.`);
   }
 };
+
+function moveCard(direction) {
+  const listbox = document.getElementById("card-order-list");
+  const options = [...listbox.querySelectorAll("fluent-option")];
+  const idx = options.findIndex((_) => _.getAttribute("aria-selected") === "true");
+  const targetIdx = idx + direction;
+  if (idx < 0 || targetIdx < 0 || targetIdx >= options.length) return;
+
+  swapOptionContents(options[idx], options[targetIdx]);
+  options[targetIdx].click();
+}
+
+window.onMoveUpCard = () => moveCard(-1);
+window.onMoveDownCard = () => moveCard(1);

--- a/tests/unit/test-config.mjs
+++ b/tests/unit/test-config.mjs
@@ -33,7 +33,7 @@ export function test_createDefaultConfig() {
         ConvertToBccThreshold: 2,
         BlockDistributionLists: true,
         EmphasizeUntrustedToCc: false,
-        ConfirmationDialogCardsOrder: [],
+        ConfirmationDialogCardsOrder: [...Config.CARD_DEFAULT_ORDER],
         FixedParameters: [],
       },
       trustedDomains: [],

--- a/tests/unit/test-config.mjs
+++ b/tests/unit/test-config.mjs
@@ -33,6 +33,7 @@ export function test_createDefaultConfig() {
         ConvertToBccThreshold: 2,
         BlockDistributionLists: true,
         EmphasizeUntrustedToCc: false,
+        ConfirmationDialogCardsOrder: [],
         FixedParameters: [],
       },
       trustedDomains: [],
@@ -103,6 +104,7 @@ test_merge.parameters = {
         ConvertToBccThreshold: 3,
         BlockDistributionLists: true,
         EmphasizeUntrustedToCc: true,
+        ConfirmationDialogCardsOrder: [],
         FixedParameters: [],
       },
       trustedDomains: ["trustedDomain"],
@@ -139,7 +141,7 @@ test_merge.parameters = {
         "ConvertToBccEnabled = true\n" +
         "ConvertToBccThreshold = 3\n" +
         "BlockDistributionLists = true\n" +
-        "EmphasizeUntrustedToCc = true",
+        "EmphasizeUntrustedToCc = true\n",
       trustedDomainsString: "trustedDomain",
       unsafeDomainsString: "unsafeDomain",
       unsafeFilesString: "unsafeFile",
@@ -172,6 +174,7 @@ test_merge.parameters = {
         ConvertToBccThreshold: 3,
         BlockDistributionLists: true,
         EmphasizeUntrustedToCc: true,
+        ConfirmationDialogCardsOrder: [],
         FixedParameters: [],
       },
       trustedDomains: ["trustedDomain"],
@@ -244,6 +247,7 @@ test_merge.parameters = {
         ConvertToBccThreshold: 3,
         BlockDistributionLists: true,
         EmphasizeUntrustedToCc: true,
+        ConfirmationDialogCardsOrder: [],
         FixedParameters: [],
       },
       trustedDomains: ["trustedDomain"],
@@ -326,6 +330,7 @@ test_merge.parameters = {
         ConvertToBccThreshold: 3,
         BlockDistributionLists: true,
         EmphasizeUntrustedToCc: true,
+        ConfirmationDialogCardsOrder: [],
         FixedParameters: [],
       },
       trustedDomains: ["trustedDomain"],
@@ -398,6 +403,7 @@ test_merge.parameters = {
         ConvertToBccThreshold: 4,
         BlockDistributionLists: true,
         EmphasizeUntrustedToCc: true,
+        ConfirmationDialogCardsOrder: [],
         FixedParameters: [],
       },
       trustedDomains: ["trustedDomain_left"],
@@ -467,6 +473,7 @@ test_merge.parameters = {
         ConvertToBccThreshold: 2,
         BlockDistributionLists: false,
         EmphasizeUntrustedToCc: false,
+        ConfirmationDialogCardsOrder: ["UntrustedDomains", "TrustedDomains", "Subject", "Body", "Misc"],
         FixedParameters: ["CountSeconds"],
       },
       trustedDomains: ["trustedDomain_right"],
@@ -505,6 +512,7 @@ test_merge.parameters = {
         "ConvertToBccThreshold = 2\n" +
         "BlockDistributionLists = false\n" +
         "EmphasizeUntrustedToCc = false\n" +
+        "ConfirmationDialogCardsOrder = UntrustedDomains,TrustedDomains,Subject,Body,Misc\n" +
         "FixedParameters = CountSeconds",
       trustedDomainsString: "trustedDomain_right",
       unsafeDomainsString: "unsafeDomain_right",
@@ -538,6 +546,7 @@ test_merge.parameters = {
         ConvertToBccThreshold: 2,
         BlockDistributionLists: false,
         EmphasizeUntrustedToCc: false,
+        ConfirmationDialogCardsOrder: ["UntrustedDomains", "TrustedDomains", "Subject", "Body", "Misc"],
         FixedParameters: ["CountSeconds"],
       },
       trustedDomains: ["trustedDomain_left", "trustedDomain_right"],
@@ -581,6 +590,7 @@ test_merge.parameters = {
         "ConvertToBccThreshold = 2\n" +
         "BlockDistributionLists = false\n" +
         "EmphasizeUntrustedToCc = false\n" +
+        "ConfirmationDialogCardsOrder = UntrustedDomains,TrustedDomains,Subject,Body,Misc\n" +
         "FixedParameters = CountSeconds",
       trustedDomainsString: "trustedDomain_left\ntrustedDomain_right",
       unsafeDomainsString: "unsafeDomain_left\n[WARNING]\nunsafeDomain_right",
@@ -622,6 +632,7 @@ test_merge.parameters = {
         ConvertToBccThreshold: 3,
         BlockDistributionLists: true,
         EmphasizeUntrustedToCc: true,
+        ConfirmationDialogCardsOrder: ["UntrustedDomains", "TrustedDomains", "Subject", "Body", "Misc"],
         FixedParameters: [
           "CountEnabled",
           "CountAllowSkip",
@@ -646,7 +657,8 @@ test_merge.parameters = {
           "TrustedDomains",
           "UnsafeDomains",
           "UnsafeFiles",
-          "UnsafeBodies"
+          "UnsafeBodies",
+          "ConfirmationDialogCardsOrder"
         ],
       },
       trustedDomains: ["trustedDomain_left"],
@@ -685,6 +697,7 @@ test_merge.parameters = {
         "ConvertToBccThreshold = 3\n" +
         "BlockDistributionLists = true\n" +
         "EmphasizeUntrustedToCc = true\n" +
+        "ConfirmationDialogCardsOrder = UntrustedDomains,TrustedDomains,Subject,Body,Misc\n" +
         "FixedParameters = " + 
             "CountEnabled," +
             "CountAllowSkip," +
@@ -707,7 +720,8 @@ test_merge.parameters = {
             "TrustedDomains," +
             "UnsafeDomains," +
             "UnsafeFiles," + 
-            "UnsafeBodies",
+            "UnsafeBodies," +
+            "ConfirmationDialogCardsOrder",
       trustedDomainsString: "trustedDomain_left",
       unsafeDomainsString: "unsafeDomain_left",
       unsafeFilesString: "unsafeFile_left",
@@ -740,6 +754,7 @@ test_merge.parameters = {
         ConvertToBccThreshold: 2,
         BlockDistributionLists: false,
         EmphasizeUntrustedToCc: false,
+        ConfirmationDialogCardsOrder: ["UntrustedDomains", "TrustedDomains", "Subject", "Body", "Misc"],
         FixedParameters: ["CountSeconds"],
       },
       trustedDomains: ["trustedDomain_right"],
@@ -773,6 +788,7 @@ test_merge.parameters = {
         "ConvertToBccThreshold = 2\n" +
         "BlockDistributionLists = false\n" +
         "EmphasizeUntrustedToCc = false\n" +
+        "ConfirmationDialogCardsOrder = UntrustedDomains,TrustedDomains,Subject,Body,Misc\n" +
         "FixedParameters = CountSeconds",
       trustedDomainsString: "trustedDomain_right",
       unsafeDomainsString: "unsafeDomain_right",
@@ -803,6 +819,7 @@ test_merge.parameters = {
         ConvertToBccThreshold: 3,
         BlockDistributionLists: true,
         EmphasizeUntrustedToCc: true,
+        ConfirmationDialogCardsOrder: ["UntrustedDomains", "TrustedDomains", "Subject", "Body", "Misc"],
         FixedParameters: [
           "CountEnabled",
           "CountAllowSkip",
@@ -827,7 +844,8 @@ test_merge.parameters = {
           "TrustedDomains",
           "UnsafeDomains",
           "UnsafeFiles",
-          "UnsafeBodies"
+          "UnsafeBodies",
+          "ConfirmationDialogCardsOrder"
         ],
       },
       trustedDomains: ["trustedDomain_left"],
@@ -866,6 +884,7 @@ test_merge.parameters = {
         "ConvertToBccThreshold = 3\n" +
         "BlockDistributionLists = true\n" +
         "EmphasizeUntrustedToCc = true\n" +
+        "ConfirmationDialogCardsOrder = UntrustedDomains,TrustedDomains,Subject,Body,Misc\n" +
         "FixedParameters = " + 
           "CountEnabled," +
           "CountAllowSkip," +
@@ -890,7 +909,8 @@ test_merge.parameters = {
           "TrustedDomains," +
           "UnsafeDomains," +
           "UnsafeFiles," + 
-          "UnsafeBodies",
+          "UnsafeBodies," +
+          "ConfirmationDialogCardsOrder",
       trustedDomainsString: "trustedDomain_left",
       unsafeDomainsString: "unsafeDomain_left",
       unsafeFilesString: "unsafeFile_left",


### PR DESCRIPTION
確認画面の項目の表示順を変更するオプションを追加。

追加したオプション: 

* オプション名: ConfirmationDialogCardsOrder
* デフォルト値: `TrustedDomains,UntrustedDomains,Subject,Body,Misc`
* 型: カンマ区切りリスト
* 指定可能な値: 
  * `TrustedDomains`
    * 登録済みドメインのメールアドレス
  * `UntrustedDomains`
    * 外部ドメインのメールアドレス
  * `Subject`
    * 件名
  * `Body`
    * 本文
  * `Misc`
    * 添付ファイル/その他の警告

なお、このオプションで指定しなかった項目についても、順番の指定がないだけで、確認画面で表示はされる。
オプションで指定されなかった項目については、指定された項目の後に不定順で並ぶ（厳密には、完全には不定ではなく項目のスワップを繰り返した結果の状態になる。）例えば、`ConfirmationDialogCardsOrder=Subject,Body`とすると、オプションで指定があるので、まず「件名」、「本文」が並び、その後ろにオプションで指定がない「登録済みドメインのメールアドレス」「外部ドメインのメールアドレス」「 添付ファイル/その他の警告」が並ぶ。この場合はこの順で並ぶ。

また、設定画面に以下のようにこのオプションを指定するためのカードを追加。
ボタンにより上下に移動できる。

<img width="1293" height="823" alt="image" src="https://github.com/user-attachments/assets/82aaccee-b4a6-4ea6-a154-1dc6eb98daf0" />

## テスト

* アプリケーションフォルダーにconfig\Common.txtがあれば、中身を空にする
* 設定画面を開く
* 「設定をリセットする」を実行する
  * [x] 「確認ダイアログの確認項目の表示順設定」が以下のようになっていること
    * 登録済みドメインのメールアドレス
    * 外部ドメインのメールアドレス
    * 件名
    * 本文
    * 添付ファイル/その他の警告
* 「件名を確認する」と「本文を確認する」にチェックを入れる
* 「設定を保存する」をクリックし、設定画面を閉じる
* 自分自身宛にメールを作成し、送信する
* 確認ダイアログが表示される
  * [x] 確認ダイアログの並び順が以下のとおりであること
    * 登録済みドメインのメールアドレス
    * 外部ドメインのメールアドレス
    * 件名
    * 本文
    * 添付ファイル/その他の警告
* キャンセルボタンを押し、送信をキャンセルする
* 設定画面を開く
  * [x] 「確認ダイアログの確認項目の表示順設定」が以下のようになっていること
    * 登録済みドメインのメールアドレス
    * 外部ドメインのメールアドレス
    * 件名
    * 本文
    * 添付ファイル/その他の警告
* 「確認ダイアログの確認項目の表示順設定」で「件名」を選択する
* 「上へ移動」ボタンを押す
  * [x] 以下の並び順になること
    * 登録済みドメインのメールアドレス
    * 件名
    * 外部ドメインのメールアドレス
    * 本文
    * 添付ファイル/その他の警告
* 再度「上へ移動」ボタンを押す
  * [x] 以下の並び順になること
    * 件名
    * 登録済みドメインのメールアドレス
    * 外部ドメインのメールアドレス
    * 本文
    * 添付ファイル/その他の警告
* 再度「上へ移動」ボタンを押す
  * [x] 以下の並び順のまま変わらないこと
    * 件名
    * 登録済みドメインのメールアドレス
    * 外部ドメインのメールアドレス
    * 本文
    * 添付ファイル/その他の警告
* 「確認ダイアログの確認項目の表示順設定」で「外部ドメインのメールアドレス」を選択する
* 「下へ移動」ボタンを押す
  * [x] 以下の並び順になること
    * 件名
    * 登録済みドメインのメールアドレス
    * 本文
    * 外部ドメインのメールアドレス
    * 添付ファイル/その他の警告
 * 再度「下へ移動」ボタンを押す
  * [x] 以下の並び順になること
    * 件名
    * 登録済みドメインのメールアドレス
    * 本文
    * 添付ファイル/その他の警告
    * 外部ドメインのメールアドレス
 * 再度「下へ移動」ボタンを押す
  * [x] 以下の並び順のまま変わらないこと
    * 件名
    * 登録済みドメインのメールアドレス
    * 本文
    * 添付ファイル/その他の警告
    * 外部ドメインのメールアドレス
* 「設定を保存する」をクリックし、設定画面を閉じる
* 自分自身宛にメールを作成し、送信する
* 確認ダイアログが表示される
  * [x] 確認ダイアログの並び順が以下のとおりであること
    * 件名
    * 登録済みドメインのメールアドレス
    * 本文
    * 添付ファイル/その他の警告
    * 外部ドメインのメールアドレス
* キャンセルボタンを押し、送信をキャンセルする
* 設定画面を開く（現在の設定が設定画面に反映されることの確認）
  * [x] 「確認ダイアログの確認項目の表示順設定」が以下のようになっていること
    * 件名
    * 登録済みドメインのメールアドレス
    * 本文
    * 添付ファイル/その他の警告
    * 外部ドメインのメールアドレス