### PR TITLE
Add DistributionList to mock

### DIFF
--- a/tests/unit/test-safe-bcc-confirmation.mjs
+++ b/tests/unit/test-safe-bcc-confirmation.mjs
@@ -21,6 +21,9 @@ const mockData = {
     ItemType: {
       Message: "message",
       Appointment: "appointment"
+    },
+    RecipientType: {
+      DistributionList: "distributionList"
     }
   }
 };


### PR DESCRIPTION
Fix the test error in CI/CD like below:

https://github.com/FlexConfirmMail/Outlook-Office-Addin/actions/runs/24657169062/job/72093478282?pr=153

```
Error: test_blockSending [NoBlock]
TypeError: Cannot read properties of undefined (reading 'DistributionList')
    at RecipientClassifier.classify (file:///home/runner/work/Outlook-Office-Addin/Outlook-Office-Addin/src/web/recipient-classifier.mjs:106:47)
    at RecipientClassifier.classifyAll (file:///home/runner/work/Outlook-Office-Addin/Outlook-Office-Addin/src/web/recipient-classifier.mjs:156:37)
    at ConfirmData.classifyTarget (file:///home/runner/work/Outlook-Office-Addin/Outlook-Office-Addin/src/web/confirm-data.mjs:71:58)
    at Module.test_blockSending (file:///home/runner/work/Outlook-Office-Addin/Outlook-Office-Addin/tests/unit/test-confirm-data.mjs:246:8)
    at async run (file:///home/runner/work/Outlook-Office-Addin/Outlook-Office-Addin/node_modules/tiny-esm-test-runner/lib/runner.js:78:9)
```

It may be caused by overwritten a global mock object, we should use the same mock in all tests.