### PR TITLE
Display cards have checkboxes

### DIFF
--- a/src/web/confirm.html
+++ b/src/web/confirm.html
@@ -21,7 +21,7 @@ Copyright (c) 2025 ClearCode Inc.
     <div class="dialog-content">
         <div class="card-container">
             <div class="cards">
-                <fluent-card id="trusted-domains-card">
+                <fluent-card id="trusted-domains-card" hidden>
                     <div class="heading-container">
                         <h3 data-l10n-text-content="confirmation_trustedCaption"></h3>
                         <fluent-button id="check-all-trusted" onclick="onCheckAllTrusted()"
@@ -31,7 +31,7 @@ Copyright (c) 2025 ClearCode Inc.
                     <div id="trusted-domains">
                     </div>
                 </fluent-card>
-                <fluent-card id="untrusted-domains-card">
+                <fluent-card id="untrusted-domains-card" hidden>
                     <h3 data-l10n-text-content="confirmation_untrustedCaption"></h3>
                     <fluent-divider></fluent-divider>
                     <div id="untrusted-domains"></div>
@@ -50,7 +50,7 @@ Copyright (c) 2025 ClearCode Inc.
                     <fluent-divider></fluent-divider>
                     <div id="mail-body"></div>
                 </fluent-card>
-                <fluent-card id="misc-card">
+                <fluent-card id="misc-card" hidden>
                     <h3 data-l10n-text-content="confirmation_miscCaption"></h3>
                     <fluent-divider></fluent-divider>
                     <div id="attachment-and-others"></div>

--- a/src/web/confirm.js
+++ b/src/web/confirm.js
@@ -194,8 +194,8 @@ function appendMiscCheckboxes({ items, warning, emphasize }) {
 
 function displayCardsHaveCheckboxes() {
   ["trusted-domains-card", "untrusted-domains-card", "misc-card"]
-    .map(id => document.querySelector(`#${id}`))
-    .forEach(card => {
+    .map((id) => document.querySelector(`#${id}`))
+    .forEach((card) => {
       if (card?.querySelector("fluent-checkbox.check-target")) {
         card.hidden = false;
       }

--- a/src/web/confirm.js
+++ b/src/web/confirm.js
@@ -192,6 +192,16 @@ function appendMiscCheckboxes({ items, warning, emphasize }) {
   }
 }
 
+function displayCardsHaveCheckboxes() {
+  ["trusted-domains-card", "untrusted-domains-card", "misc-card"]
+    .map(id => document.querySelector(`#${id}`))
+    .forEach(card => {
+      if (card?.querySelector("fluent-checkbox.check-target")) {
+        card.hidden = false;
+      }
+    });
+}
+
 function appendCheckbox({ container, id, label, warning, emphasize }) {
   if (!id) {
     id = generateTempId();
@@ -363,5 +373,6 @@ async function onMessageFromParent(arg) {
     }
   }
   reorderCards(data.config.common.ConfirmationDialogCardsOrder);
+  displayCardsHaveCheckboxes();
   Dialog.resizeToContent();
 }


### PR DESCRIPTION
Display only cards that have checkboxes.

## Test

* Open the FlexConfirmMail setting dialog
* Reset setting
* Close the setting dialog
* Try to send mail to test@example.com
 * [x] Confirm that only internal domains is displayed in the confirmation dialog
 * <img width="687" height="420" alt="image" src="https://github.com/user-attachments/assets/29c94d3b-0f7d-4669-90e2-01ca3cde642b" />
* Click the checkbox in the confirmation dialog
   * [x] Confirm that "Send" button is enabled
* Close the confirmation dialog with the Cancel button
* Try to send mail to test@external.example.com
 * [x] Confirm that only external domains is displayed in the confirmation dialog
 * <img width="701" height="647" alt="image" src="https://github.com/user-attachments/assets/42ea2e31-0f02-4f26-99fe-4665bb523e38" />
* Click the checkbox in the confirmation dialog
   * [x] Confirm that "Send" button is enabled
* Close the confirmation dialog with the Cancel button
* Try to send mail to test@example.jp
 * [x] Confirm that external domains and misc ( a warning for unsafe domains ) are displayed in the confirmation dialog
 * <img width="694" height="468" alt="image" src="https://github.com/user-attachments/assets/e03e9de2-d6f1-4bb7-bd05-dd32074a0b27" />
* Click the checkboxes in the confirmation dialog
   * [x] Confirm that "Send" button is enabled
* Close the confirmation dialog with the Cancel button