### PR TITLE
Modify style of the confirmation dialog

### DIFF
--- a/src/web/app.js
+++ b/src/web/app.js
@@ -155,7 +155,7 @@ async function tryConfirm(data, asyncContext) {
     data,
     asyncContext,
     height: Math.min(60, charsToPercentage(50, screen.availHeight)),
-    width: Math.min(80, charsToPercentage(60, screen.availWidth)),
+    width: Math.min(90, charsToPercentage(90, screen.availWidth)),
   });
   console.debug("status: ", status);
 

--- a/src/web/confirm.css
+++ b/src/web/confirm.css
@@ -7,7 +7,12 @@ Copyright (c) 2025 ClearCode Inc.
 */
 .heading-container {
   display: flex;
-  align-items: center;
+  align-items: end;
+  margin-bottom: 0;
+}
+
+.heading-container h3 {
+  margin-bottom: 0;
 }
 
 .heading-container fluent-button {

--- a/src/web/confirm.css
+++ b/src/web/confirm.css
@@ -173,3 +173,19 @@ pre {
   word-wrap: break-word;
   overflow-wrap: break-word;
 }
+
+#trusted-domains-card {
+    container-type: inline-size;
+}
+
+@container (max-width: 430px) {
+    #trusted-domains-card .heading-container {
+        flex-direction: column-reverse; /* DOM 順は h3 → button、視覚順を逆転 */
+        align-items: flex-start;
+    }
+
+    #check-all-trusted {
+        margin-top: 10px;
+        margin-left: 0;
+    }
+}


### PR DESCRIPTION
送信前確認ダイアログの起動時のサイズを横長になるように修正。

また、「登録済みドメインのメールアドレス」のスタイルに若干の問題があったため修正。

* タイトル部分のサイズが不必要にその他のカード（「添付ファイル/その他の警告」）より大きくなっていた問題を修正。
* 送信前確認ダイアログの横幅が短い時に、「一括チェック」ボタンが上に表示されるように調整

## 修正前

<img width="727" height="173" alt="image" src="https://github.com/user-attachments/assets/3b8d843b-a197-4472-b658-f5dbb9ed6e59" />

<img width="294" height="209" alt="image" src="https://github.com/user-attachments/assets/777b4dcb-6c39-4f2a-99e6-0b9d07bb0e37" />

幅が狭い時、ボタンが隠れる。

## 修正後

<img width="963" height="155" alt="image" src="https://github.com/user-attachments/assets/5bf6a169-332b-4810-8dff-35fe3dbcf523" />

<img width="415" height="210" alt="image" src="https://github.com/user-attachments/assets/c7f1f9e8-07f1-464b-802b-a0fc8a4d5267" />

# テスト

* [x] 送信前確認ダイアログの起動時、修正前よりも横長に表示されること
* [x] 上記の説明欄に記載の通り、「登録済みドメインのメールアドレス」のスタイルが変わっていること