### PR TITLE
Add option to Ignore inline attachments

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -105,6 +105,7 @@
   "setting_requireCheckBody": "Require to check the message body",
   "setting_configBlockDistributionLists":	"Block sending if unexpanded distribution lists or contact groups are included",
   "setting_configEmphasizeUntrustedToCc": "Emphasize external domains in To/Cc fields",
+  "setting_configIgnoreInlineAttachments": "Exclude inline attachments",
   "setting_configConfirmationDialogCardsOrder": "Confirmation Dialog Items Order",
   "setting_cardsOrderTrustedCaption": "Internal Recipients",
   "setting_cardsOrderUntrustedCaption": "External Recipients",

--- a/locales/en.json
+++ b/locales/en.json
@@ -105,7 +105,7 @@
   "setting_requireCheckBody": "Require to check the message body",
   "setting_configBlockDistributionLists":	"Block sending if unexpanded distribution lists or contact groups are included",
   "setting_configEmphasizeUntrustedToCc": "Emphasize external domains in To/Cc fields",
-  "setting_configIgnoreInlineAttachments": "Exclude inline attachments",
+  "setting_configIgnoreInlineAttachments": "Exclude inline image attachments from confirmation",
   "setting_configConfirmationDialogCardsOrder": "Confirmation Dialog Items Order",
   "setting_cardsOrderTrustedCaption": "Internal Recipients",
   "setting_cardsOrderUntrustedCaption": "External Recipients",

--- a/locales/en.json
+++ b/locales/en.json
@@ -105,7 +105,7 @@
   "setting_requireCheckBody": "Require to check the message body",
   "setting_configBlockDistributionLists":	"Block sending if unexpanded distribution lists or contact groups are included",
   "setting_configEmphasizeUntrustedToCc": "Emphasize external domains in To/Cc fields",
-  "setting_configIgnoreInlineAttachments": "Exclude inline image attachments from confirmation",
+  "setting_configIgnoreInlineImageAttachments": "Exclude inline image attachments from confirmation",
   "setting_configConfirmationDialogCardsOrder": "Confirmation Dialog Items Order",
   "setting_cardsOrderTrustedCaption": "Internal Recipients",
   "setting_cardsOrderUntrustedCaption": "External Recipients",

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -105,6 +105,7 @@
   "setting_requireCheckBody": "メール本文の確認を求める",
   "setting_configBlockDistributionLists": "未展開の配布リスト、連絡グループが含まれる場合、送信を禁止する",
   "setting_configEmphasizeUntrustedToCc": "社外ドメインのTo・CCを強調表示する",
+  "setting_configIgnoreInlineAttachments": "本文に挿入されたインライン添付ファイルを確認対象から除外する",
   "setting_configConfirmationDialogCardsOrder": "確認ダイアログの確認項目の表示順設定",
   "setting_cardsOrderTrustedCaption": "登録済みドメインのメールアドレス",
   "setting_cardsOrderUntrustedCaption": "外部ドメインのメールアドレス",

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -105,7 +105,7 @@
   "setting_requireCheckBody": "メール本文の確認を求める",
   "setting_configBlockDistributionLists": "未展開の配布リスト、連絡グループが含まれる場合、送信を禁止する",
   "setting_configEmphasizeUntrustedToCc": "社外ドメインのTo・CCを強調表示する",
-  "setting_configIgnoreInlineAttachments": "本文に挿入されたインライン添付ファイルを確認対象から除外する",
+  "setting_configIgnoreInlineAttachments": "本文中に挿入された画像添付ファイルを確認対象から除外する",
   "setting_configConfirmationDialogCardsOrder": "確認ダイアログの確認項目の表示順設定",
   "setting_cardsOrderTrustedCaption": "登録済みドメインのメールアドレス",
   "setting_cardsOrderUntrustedCaption": "外部ドメインのメールアドレス",

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -105,7 +105,7 @@
   "setting_requireCheckBody": "メール本文の確認を求める",
   "setting_configBlockDistributionLists": "未展開の配布リスト、連絡グループが含まれる場合、送信を禁止する",
   "setting_configEmphasizeUntrustedToCc": "社外ドメインのTo・CCを強調表示する",
-  "setting_configIgnoreInlineAttachments": "本文中に挿入された画像添付ファイルを確認対象から除外する",
+  "setting_configIgnoreInlineImageAttachments": "本文中に挿入された画像添付ファイルを確認対象から除外する",
   "setting_configConfirmationDialogCardsOrder": "確認ダイアログの確認項目の表示順設定",
   "setting_cardsOrderTrustedCaption": "登録済みドメインのメールアドレス",
   "setting_cardsOrderUntrustedCaption": "外部ドメインのメールアドレス",

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -105,7 +105,7 @@
   "setting_requireCheckBody": "要求确认电子邮件的文本",
   "setting_configBlockDistributionLists":	"如果包含未展开的分发列表、联系人组，则禁止发送",
   "setting_configEmphasizeUntrustedToCc": "将外部域名的收件人（To）・抄送（CC）高亮显示",
-  "setting_configIgnoreInlineAttachments": "将正文中插入的图片等内嵌附件从确认对象中排除",
+  "setting_configIgnoreInlineAttachments": "确认时排除内嵌图片附件",
   "setting_configConfirmationDialogCardsOrder": "确认对话框的确认项目的显示顺序设置",
   "setting_cardsOrderTrustedCaption": "信任域，地址",
   "setting_cardsOrderUntrustedCaption": "外部目的地",

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -105,6 +105,7 @@
   "setting_requireCheckBody": "要求确认电子邮件的文本",
   "setting_configBlockDistributionLists":	"如果包含未展开的分发列表、联系人组，则禁止发送",
   "setting_configEmphasizeUntrustedToCc": "将外部域名的收件人（To）・抄送（CC）高亮显示",
+  "setting_configIgnoreInlineAttachments": "将正文中插入的图片等内嵌附件从确认对象中排除",
   "setting_configConfirmationDialogCardsOrder": "确认对话框的确认项目的显示顺序设置",
   "setting_cardsOrderTrustedCaption": "信任域，地址",
   "setting_cardsOrderUntrustedCaption": "外部目的地",

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -105,7 +105,7 @@
   "setting_requireCheckBody": "要求确认电子邮件的文本",
   "setting_configBlockDistributionLists":	"如果包含未展开的分发列表、联系人组，则禁止发送",
   "setting_configEmphasizeUntrustedToCc": "将外部域名的收件人（To）・抄送（CC）高亮显示",
-  "setting_configIgnoreInlineAttachments": "确认时排除内嵌图片附件",
+  "setting_configIgnoreInlineImageAttachments": "确认时排除内嵌图片附件",
   "setting_configConfirmationDialogCardsOrder": "确认对话框的确认项目的显示顺序设置",
   "setting_cardsOrderTrustedCaption": "信任域，地址",
   "setting_cardsOrderUntrustedCaption": "外部目的地",

--- a/src/web/config.mjs
+++ b/src/web/config.mjs
@@ -185,7 +185,7 @@ export class Config {
     ConvertToBccThreshold: "number",
     BlockDistributionLists: "boolean",
     EmphasizeUntrustedToCc: "boolean",
-    IgnoreInlineAttachments: "boolean",
+    IgnoreInlineImageAttachments: "boolean",
     ConfirmationDialogCardsOrder: "commaSeparatedValues",
     FixedParameters: "commaSeparatedValues",
   };
@@ -223,7 +223,7 @@ export class Config {
         ConvertToBccThreshold: 2,
         BlockDistributionLists: true,
         EmphasizeUntrustedToCc: false,
-        IgnoreInlineAttachments: false,
+        IgnoreInlineImageAttachments: false,
         ConfirmationDialogCardsOrder: [...Config.CARD_DEFAULT_ORDER],
         FixedParameters: [],
       },

--- a/src/web/config.mjs
+++ b/src/web/config.mjs
@@ -185,6 +185,7 @@ export class Config {
     ConvertToBccThreshold: "number",
     BlockDistributionLists: "boolean",
     EmphasizeUntrustedToCc: "boolean",
+    IgnoreInlineAttachments: "boolean",
     ConfirmationDialogCardsOrder: "commaSeparatedValues",
     FixedParameters: "commaSeparatedValues",
   };
@@ -222,6 +223,7 @@ export class Config {
         ConvertToBccThreshold: 2,
         BlockDistributionLists: true,
         EmphasizeUntrustedToCc: false,
+        IgnoreInlineAttachments: false,
         ConfirmationDialogCardsOrder: [...Config.CARD_DEFAULT_ORDER],
         FixedParameters: [],
       },

--- a/src/web/confirm-data.mjs
+++ b/src/web/confirm-data.mjs
@@ -44,6 +44,11 @@ import { OfficeDataAccessHelper } from "./office-data-access-helper.mjs";
 //   itemType: Office.MailboxEnums.ItemType.Message,
 // }
 export class ConfirmData {
+  // Compose mode does not provide the content type of attachments, so inline
+  // image attachments are detected by their file name extensions.
+  static INLINE_IMAGE_EXTENSIONS =
+    /\.(a?png|jpe?g|jpe|jfif|pjpe?g|pjp|gif|bmp|dib|rle|svgz?|webp|tiff?|ico|cur|emf|wmf|emz|wmz|avif|heic|heif|jxl|jxr|hdp|wdp|tga|psd|pcx|xbm|pbm|pgm|ppm|pnm)$/i;
+
   target;
   config;
   originalRecipients;
@@ -176,9 +181,10 @@ export class ConfirmData {
     messageData.locale = locale;
     const confirmData = new ConfirmData(messageData);
     confirmData.config = await ConfigLoader.loadEffectiveConfig();
-    if (confirmData.config.common.IgnoreInlineAttachments) {
+    if (confirmData.config.common.IgnoreInlineImageAttachments) {
       confirmData.target.attachments = (confirmData.target.attachments || []).filter(
-        (attachment) => !attachment.isInline
+        (attachment) =>
+          !(attachment.isInline && ConfirmData.INLINE_IMAGE_EXTENSIONS.test(attachment.name))
       );
     }
     confirmData.classifyTarget();

--- a/src/web/confirm-data.mjs
+++ b/src/web/confirm-data.mjs
@@ -176,6 +176,11 @@ export class ConfirmData {
     messageData.locale = locale;
     const confirmData = new ConfirmData(messageData);
     confirmData.config = await ConfigLoader.loadEffectiveConfig();
+    if (confirmData.config.common.IgnoreInlineAttachments) {
+      confirmData.target.attachments = (confirmData.target.attachments || []).filter(
+        (attachment) => !attachment.isInline
+      );
+    }
     confirmData.classifyTarget();
     confirmData.setUnsafeBodiesBlockStatus(locale.language);
     return confirmData;

--- a/src/web/setting.html
+++ b/src/web/setting.html
@@ -77,7 +77,7 @@ Copyright (c) 2025 ClearCode Inc.
                     <fluent-checkbox id="AppointmentConfirmationEnabled" data-l10n-text-content="setting_configAppointmentConfirmationEnabled"></fluent-checkbox><br />
                     <fluent-checkbox id="blockDistributionLists" data-l10n-text-content="setting_configBlockDistributionLists"></fluent-checkbox><br />
                     <fluent-checkbox id="emphasizeUntrustedToCc" data-l10n-text-content="setting_configEmphasizeUntrustedToCc"></fluent-checkbox><br />
-                    <fluent-checkbox id="ignoreInlineAttachments" data-l10n-text-content="setting_configIgnoreInlineAttachments"></fluent-checkbox>
+                    <fluent-checkbox id="ignoreInlineImageAttachments" data-l10n-text-content="setting_configIgnoreInlineImageAttachments"></fluent-checkbox>
                 </fluent-card>
             </fluent-tab-panel>
             <fluent-tab-panel id="trustedDomainsPanel">

--- a/src/web/setting.html
+++ b/src/web/setting.html
@@ -76,7 +76,8 @@ Copyright (c) 2025 ClearCode Inc.
                     <fluent-checkbox id="countSkipIfNoExt" data-l10n-text-content="setting_configCountSkipIfNoExt"></fluent-checkbox><br />
                     <fluent-checkbox id="AppointmentConfirmationEnabled" data-l10n-text-content="setting_configAppointmentConfirmationEnabled"></fluent-checkbox><br />
                     <fluent-checkbox id="blockDistributionLists" data-l10n-text-content="setting_configBlockDistributionLists"></fluent-checkbox><br />
-                    <fluent-checkbox id="emphasizeUntrustedToCc" data-l10n-text-content="setting_configEmphasizeUntrustedToCc"></fluent-checkbox>
+                    <fluent-checkbox id="emphasizeUntrustedToCc" data-l10n-text-content="setting_configEmphasizeUntrustedToCc"></fluent-checkbox><br />
+                    <fluent-checkbox id="ignoreInlineAttachments" data-l10n-text-content="setting_configIgnoreInlineAttachments"></fluent-checkbox>
                 </fluent-card>
             </fluent-tab-panel>
             <fluent-tab-panel id="trustedDomainsPanel">

--- a/src/web/setting.js
+++ b/src/web/setting.js
@@ -424,6 +424,10 @@ function updateDialogSetting(policy, user) {
   document.getElementById("emphasizeUntrustedToCc").checked = common.EmphasizeUntrustedToCc;
   document.getElementById("emphasizeUntrustedToCc").disabled =
     fixedParametersSet.has("EmphasizeUntrustedToCc");
+  document.getElementById("ignoreInlineAttachments").checked = common.IgnoreInlineAttachments;
+  document.getElementById("ignoreInlineAttachments").disabled = fixedParametersSet.has(
+    "IgnoreInlineAttachments"
+  );
   reorderListbox(common.ConfirmationDialogCardsOrder ?? []);
   if (fixedParametersSet.has("ConfirmationDialogCardsOrder")) {
     const listbox = document.getElementById("cardOrderList");
@@ -486,6 +490,7 @@ function serializeCommonConfigs({ mode = Setting.SerializationMode.User }) {
   const convertToBccThreshold = document.getElementById("convertToBccThreshold").value;
   const blockDistributionLists = document.getElementById("blockDistributionLists").checked;
   const emphasizeUntrustedToCc = document.getElementById("emphasizeUntrustedToCc").checked;
+  const ignoreInlineAttachments = document.getElementById("ignoreInlineAttachments").checked;
   const confirmationDialogCardsOrder = [
     ...document.querySelectorAll("#cardOrderList fluent-option"),
   ]
@@ -535,6 +540,11 @@ function serializeCommonConfigs({ mode = Setting.SerializationMode.User }) {
     mode,
     "EmphasizeUntrustedToCc",
     emphasizeUntrustedToCc
+  );
+  commonConfigString += serializeCommonConfig(
+    mode,
+    "IgnoreInlineAttachments",
+    ignoreInlineAttachments
   );
   commonConfigString += serializeCommonConfig(
     mode,

--- a/src/web/setting.js
+++ b/src/web/setting.js
@@ -425,9 +425,8 @@ function updateDialogSetting(policy, user) {
   document.getElementById("emphasizeUntrustedToCc").disabled =
     fixedParametersSet.has("EmphasizeUntrustedToCc");
   document.getElementById("ignoreInlineAttachments").checked = common.IgnoreInlineAttachments;
-  document.getElementById("ignoreInlineAttachments").disabled = fixedParametersSet.has(
-    "IgnoreInlineAttachments"
-  );
+  document.getElementById("ignoreInlineAttachments").disabled =
+    fixedParametersSet.has("IgnoreInlineAttachments");
   reorderListbox(common.ConfirmationDialogCardsOrder ?? []);
   if (fixedParametersSet.has("ConfirmationDialogCardsOrder")) {
     const listbox = document.getElementById("cardOrderList");

--- a/src/web/setting.js
+++ b/src/web/setting.js
@@ -424,9 +424,11 @@ function updateDialogSetting(policy, user) {
   document.getElementById("emphasizeUntrustedToCc").checked = common.EmphasizeUntrustedToCc;
   document.getElementById("emphasizeUntrustedToCc").disabled =
     fixedParametersSet.has("EmphasizeUntrustedToCc");
-  document.getElementById("ignoreInlineAttachments").checked = common.IgnoreInlineAttachments;
-  document.getElementById("ignoreInlineAttachments").disabled =
-    fixedParametersSet.has("IgnoreInlineAttachments");
+  document.getElementById("ignoreInlineImageAttachments").checked =
+    common.IgnoreInlineImageAttachments;
+  document.getElementById("ignoreInlineImageAttachments").disabled = fixedParametersSet.has(
+    "IgnoreInlineImageAttachments"
+  );
   reorderListbox(common.ConfirmationDialogCardsOrder ?? []);
   if (fixedParametersSet.has("ConfirmationDialogCardsOrder")) {
     const listbox = document.getElementById("cardOrderList");
@@ -489,7 +491,9 @@ function serializeCommonConfigs({ mode = Setting.SerializationMode.User }) {
   const convertToBccThreshold = document.getElementById("convertToBccThreshold").value;
   const blockDistributionLists = document.getElementById("blockDistributionLists").checked;
   const emphasizeUntrustedToCc = document.getElementById("emphasizeUntrustedToCc").checked;
-  const ignoreInlineAttachments = document.getElementById("ignoreInlineAttachments").checked;
+  const ignoreInlineImageAttachments = document.getElementById(
+    "ignoreInlineImageAttachments"
+  ).checked;
   const confirmationDialogCardsOrder = [
     ...document.querySelectorAll("#cardOrderList fluent-option"),
   ]
@@ -542,8 +546,8 @@ function serializeCommonConfigs({ mode = Setting.SerializationMode.User }) {
   );
   commonConfigString += serializeCommonConfig(
     mode,
-    "IgnoreInlineAttachments",
-    ignoreInlineAttachments
+    "IgnoreInlineImageAttachments",
+    ignoreInlineImageAttachments
   );
   commonConfigString += serializeCommonConfig(
     mode,

--- a/tests/unit/test-config.mjs
+++ b/tests/unit/test-config.mjs
@@ -33,7 +33,7 @@ export function test_createDefaultConfig() {
         ConvertToBccThreshold: 2,
         BlockDistributionLists: true,
         EmphasizeUntrustedToCc: false,
-        IgnoreInlineAttachments: false,
+        IgnoreInlineImageAttachments: false,
         ConfirmationDialogCardsOrder: [...Config.CARD_DEFAULT_ORDER],
         FixedParameters: [],
       },
@@ -105,7 +105,7 @@ test_merge.parameters = {
         ConvertToBccThreshold: 3,
         BlockDistributionLists: true,
         EmphasizeUntrustedToCc: true,
-        IgnoreInlineAttachments: true,
+        IgnoreInlineImageAttachments: true,
         ConfirmationDialogCardsOrder: [],
         FixedParameters: [],
       },
@@ -144,7 +144,7 @@ test_merge.parameters = {
         "ConvertToBccThreshold = 3\n" +
         "BlockDistributionLists = true\n" +
         "EmphasizeUntrustedToCc = true\n" +
-        "IgnoreInlineAttachments = true\n",
+        "IgnoreInlineImageAttachments = true\n",
       trustedDomainsString: "trustedDomain",
       unsafeDomainsString: "unsafeDomain",
       unsafeFilesString: "unsafeFile",
@@ -177,7 +177,7 @@ test_merge.parameters = {
         ConvertToBccThreshold: 3,
         BlockDistributionLists: true,
         EmphasizeUntrustedToCc: true,
-        IgnoreInlineAttachments: true,
+        IgnoreInlineImageAttachments: true,
         ConfirmationDialogCardsOrder: [],
         FixedParameters: [],
       },
@@ -217,7 +217,7 @@ test_merge.parameters = {
         "ConvertToBccThreshold = 3\n" +
         "BlockDistributionLists = true\n" +
         "EmphasizeUntrustedToCc = true\n" +
-        "IgnoreInlineAttachments = true",
+        "IgnoreInlineImageAttachments = true",
       trustedDomainsString: "trustedDomain",
       unsafeDomainsString: "unsafeDomain",
       unsafeFilesString: "unsafeFile",
@@ -252,7 +252,7 @@ test_merge.parameters = {
         ConvertToBccThreshold: 3,
         BlockDistributionLists: true,
         EmphasizeUntrustedToCc: true,
-        IgnoreInlineAttachments: true,
+        IgnoreInlineImageAttachments: true,
         ConfirmationDialogCardsOrder: [],
         FixedParameters: [],
       },
@@ -292,7 +292,7 @@ test_merge.parameters = {
         "ConvertToBccThreshold = 3\n" +
         "BlockDistributionLists = true\n" +
         "EmphasizeUntrustedToCc = true\n" +
-        "IgnoreInlineAttachments = true",
+        "IgnoreInlineImageAttachments = true",
       trustedDomainsString: "trustedDomain",
       unsafeDomainsString: "unsafeDomain",
       unsafeFilesString: "unsafeFile",
@@ -337,7 +337,7 @@ test_merge.parameters = {
         ConvertToBccThreshold: 3,
         BlockDistributionLists: true,
         EmphasizeUntrustedToCc: true,
-        IgnoreInlineAttachments: true,
+        IgnoreInlineImageAttachments: true,
         ConfirmationDialogCardsOrder: [],
         FixedParameters: [],
       },
@@ -377,7 +377,7 @@ test_merge.parameters = {
         "ConvertToBccThreshold = 3\n" +
         "BlockDistributionLists = true\n" +
         "EmphasizeUntrustedToCc = true\n" +
-        "IgnoreInlineAttachments = true",
+        "IgnoreInlineImageAttachments = true",
       trustedDomainsString: "trustedDomain",
       unsafeDomainsString: "unsafeDomain",
       unsafeFilesString: "unsafeFile",
@@ -412,7 +412,7 @@ test_merge.parameters = {
         ConvertToBccThreshold: 4,
         BlockDistributionLists: true,
         EmphasizeUntrustedToCc: true,
-        IgnoreInlineAttachments: true,
+        IgnoreInlineImageAttachments: true,
         ConfirmationDialogCardsOrder: [],
         FixedParameters: [],
       },
@@ -451,7 +451,7 @@ test_merge.parameters = {
         "ConvertToBccThreshold = 4\n" +
         "BlockDistributionLists = true\n" +
         "EmphasizeUntrustedToCc = true\n" +
-        "IgnoreInlineAttachments = true",
+        "IgnoreInlineImageAttachments = true",
       trustedDomainsString: "trustedDomain_left",
       unsafeDomainsString: "unsafeDomain_left",
       unsafeFilesString: "unsafeFile_left",
@@ -484,7 +484,7 @@ test_merge.parameters = {
         ConvertToBccThreshold: 2,
         BlockDistributionLists: false,
         EmphasizeUntrustedToCc: false,
-        IgnoreInlineAttachments: false,
+        IgnoreInlineImageAttachments: false,
         ConfirmationDialogCardsOrder: ["UntrustedDomains", "TrustedDomains", "Subject", "Body", "Misc"],
         FixedParameters: ["CountSeconds"],
       },
@@ -524,7 +524,7 @@ test_merge.parameters = {
         "ConvertToBccThreshold = 2\n" +
         "BlockDistributionLists = false\n" +
         "EmphasizeUntrustedToCc = false\n" +
-        "IgnoreInlineAttachments = false\n" +
+        "IgnoreInlineImageAttachments = false\n" +
         "ConfirmationDialogCardsOrder = UntrustedDomains,TrustedDomains,Subject,Body,Misc\n" +
         "FixedParameters = CountSeconds",
       trustedDomainsString: "trustedDomain_right",
@@ -559,7 +559,7 @@ test_merge.parameters = {
         ConvertToBccThreshold: 2,
         BlockDistributionLists: false,
         EmphasizeUntrustedToCc: false,
-        IgnoreInlineAttachments: false,
+        IgnoreInlineImageAttachments: false,
         ConfirmationDialogCardsOrder: ["UntrustedDomains", "TrustedDomains", "Subject", "Body", "Misc"],
         FixedParameters: ["CountSeconds"],
       },
@@ -604,7 +604,7 @@ test_merge.parameters = {
         "ConvertToBccThreshold = 2\n" +
         "BlockDistributionLists = false\n" +
         "EmphasizeUntrustedToCc = false\n" +
-        "IgnoreInlineAttachments = false\n" +
+        "IgnoreInlineImageAttachments = false\n" +
         "ConfirmationDialogCardsOrder = UntrustedDomains,TrustedDomains,Subject,Body,Misc\n" +
         "FixedParameters = CountSeconds",
       trustedDomainsString: "trustedDomain_left\ntrustedDomain_right",
@@ -647,7 +647,7 @@ test_merge.parameters = {
         ConvertToBccThreshold: 3,
         BlockDistributionLists: true,
         EmphasizeUntrustedToCc: true,
-        IgnoreInlineAttachments: true,
+        IgnoreInlineImageAttachments: true,
         ConfirmationDialogCardsOrder: ["UntrustedDomains", "TrustedDomains", "Subject", "Body", "Misc"],
         FixedParameters: [
           "CountEnabled",
@@ -670,7 +670,7 @@ test_merge.parameters = {
           "ConvertToBccThreshold",
           "BlockDistributionLists",
           "EmphasizeUntrustedToCc",
-          "IgnoreInlineAttachments",
+          "IgnoreInlineImageAttachments",
           "TrustedDomains",
           "UnsafeDomains",
           "UnsafeFiles",
@@ -714,7 +714,7 @@ test_merge.parameters = {
         "ConvertToBccThreshold = 3\n" +
         "BlockDistributionLists = true\n" +
         "EmphasizeUntrustedToCc = true\n" +
-        "IgnoreInlineAttachments = true\n" +
+        "IgnoreInlineImageAttachments = true\n" +
         "ConfirmationDialogCardsOrder = UntrustedDomains,TrustedDomains,Subject,Body,Misc\n" +
         "FixedParameters = " + 
             "CountEnabled," +
@@ -735,7 +735,7 @@ test_merge.parameters = {
             "ConvertToBccThreshold," +
             "BlockDistributionLists," +
             "EmphasizeUntrustedToCc," +
-            "IgnoreInlineAttachments," +
+            "IgnoreInlineImageAttachments," +
             "TrustedDomains," +
             "UnsafeDomains," +
             "UnsafeFiles," + 
@@ -773,7 +773,7 @@ test_merge.parameters = {
         ConvertToBccThreshold: 2,
         BlockDistributionLists: false,
         EmphasizeUntrustedToCc: false,
-        IgnoreInlineAttachments: false,
+        IgnoreInlineImageAttachments: false,
         ConfirmationDialogCardsOrder: ["UntrustedDomains", "TrustedDomains", "Subject", "Body", "Misc"],
         FixedParameters: ["CountSeconds"],
       },
@@ -808,7 +808,7 @@ test_merge.parameters = {
         "ConvertToBccThreshold = 2\n" +
         "BlockDistributionLists = false\n" +
         "EmphasizeUntrustedToCc = false\n" +
-        "IgnoreInlineAttachments = false\n" +
+        "IgnoreInlineImageAttachments = false\n" +
         "ConfirmationDialogCardsOrder = UntrustedDomains,TrustedDomains,Subject,Body,Misc\n" +
         "FixedParameters = CountSeconds",
       trustedDomainsString: "trustedDomain_right",
@@ -840,7 +840,7 @@ test_merge.parameters = {
         ConvertToBccThreshold: 3,
         BlockDistributionLists: true,
         EmphasizeUntrustedToCc: true,
-        IgnoreInlineAttachments: true,
+        IgnoreInlineImageAttachments: true,
         ConfirmationDialogCardsOrder: ["UntrustedDomains", "TrustedDomains", "Subject", "Body", "Misc"],
         FixedParameters: [
           "CountEnabled",
@@ -863,7 +863,7 @@ test_merge.parameters = {
           "ConvertToBccThreshold",
           "BlockDistributionLists",
           "EmphasizeUntrustedToCc",
-          "IgnoreInlineAttachments",
+          "IgnoreInlineImageAttachments",
           "TrustedDomains",
           "UnsafeDomains",
           "UnsafeFiles",
@@ -907,7 +907,7 @@ test_merge.parameters = {
         "ConvertToBccThreshold = 3\n" +
         "BlockDistributionLists = true\n" +
         "EmphasizeUntrustedToCc = true\n" +
-        "IgnoreInlineAttachments = true\n" +
+        "IgnoreInlineImageAttachments = true\n" +
         "ConfirmationDialogCardsOrder = UntrustedDomains,TrustedDomains,Subject,Body,Misc\n" +
         "FixedParameters = " + 
           "CountEnabled," +
@@ -930,7 +930,7 @@ test_merge.parameters = {
           "ConvertToBccThreshold," +
           "BlockDistributionLists," +
           "EmphasizeUntrustedToCc," +
-          "IgnoreInlineAttachments," +
+          "IgnoreInlineImageAttachments," +
           "TrustedDomains," +
           "UnsafeDomains," +
           "UnsafeFiles," + 

--- a/tests/unit/test-config.mjs
+++ b/tests/unit/test-config.mjs
@@ -33,6 +33,7 @@ export function test_createDefaultConfig() {
         ConvertToBccThreshold: 2,
         BlockDistributionLists: true,
         EmphasizeUntrustedToCc: false,
+        IgnoreInlineAttachments: false,
         ConfirmationDialogCardsOrder: [...Config.CARD_DEFAULT_ORDER],
         FixedParameters: [],
       },
@@ -104,6 +105,7 @@ test_merge.parameters = {
         ConvertToBccThreshold: 3,
         BlockDistributionLists: true,
         EmphasizeUntrustedToCc: true,
+        IgnoreInlineAttachments: true,
         ConfirmationDialogCardsOrder: [],
         FixedParameters: [],
       },
@@ -141,7 +143,8 @@ test_merge.parameters = {
         "ConvertToBccEnabled = true\n" +
         "ConvertToBccThreshold = 3\n" +
         "BlockDistributionLists = true\n" +
-        "EmphasizeUntrustedToCc = true\n",
+        "EmphasizeUntrustedToCc = true\n" +
+        "IgnoreInlineAttachments = true\n",
       trustedDomainsString: "trustedDomain",
       unsafeDomainsString: "unsafeDomain",
       unsafeFilesString: "unsafeFile",
@@ -174,6 +177,7 @@ test_merge.parameters = {
         ConvertToBccThreshold: 3,
         BlockDistributionLists: true,
         EmphasizeUntrustedToCc: true,
+        IgnoreInlineAttachments: true,
         ConfirmationDialogCardsOrder: [],
         FixedParameters: [],
       },
@@ -212,7 +216,8 @@ test_merge.parameters = {
         "ConvertToBccEnabled = true\n" +
         "ConvertToBccThreshold = 3\n" +
         "BlockDistributionLists = true\n" +
-        "EmphasizeUntrustedToCc = true",
+        "EmphasizeUntrustedToCc = true\n" +
+        "IgnoreInlineAttachments = true",
       trustedDomainsString: "trustedDomain",
       unsafeDomainsString: "unsafeDomain",
       unsafeFilesString: "unsafeFile",
@@ -247,6 +252,7 @@ test_merge.parameters = {
         ConvertToBccThreshold: 3,
         BlockDistributionLists: true,
         EmphasizeUntrustedToCc: true,
+        IgnoreInlineAttachments: true,
         ConfirmationDialogCardsOrder: [],
         FixedParameters: [],
       },
@@ -285,7 +291,8 @@ test_merge.parameters = {
         "ConvertToBccEnabled = true\n" +
         "ConvertToBccThreshold = 3\n" +
         "BlockDistributionLists = true\n" +
-        "EmphasizeUntrustedToCc = true",
+        "EmphasizeUntrustedToCc = true\n" +
+        "IgnoreInlineAttachments = true",
       trustedDomainsString: "trustedDomain",
       unsafeDomainsString: "unsafeDomain",
       unsafeFilesString: "unsafeFile",
@@ -330,6 +337,7 @@ test_merge.parameters = {
         ConvertToBccThreshold: 3,
         BlockDistributionLists: true,
         EmphasizeUntrustedToCc: true,
+        IgnoreInlineAttachments: true,
         ConfirmationDialogCardsOrder: [],
         FixedParameters: [],
       },
@@ -368,7 +376,8 @@ test_merge.parameters = {
         "ConvertToBccEnabled = true\n" +
         "ConvertToBccThreshold = 3\n" +
         "BlockDistributionLists = true\n" +
-        "EmphasizeUntrustedToCc = true",
+        "EmphasizeUntrustedToCc = true\n" +
+        "IgnoreInlineAttachments = true",
       trustedDomainsString: "trustedDomain",
       unsafeDomainsString: "unsafeDomain",
       unsafeFilesString: "unsafeFile",
@@ -403,6 +412,7 @@ test_merge.parameters = {
         ConvertToBccThreshold: 4,
         BlockDistributionLists: true,
         EmphasizeUntrustedToCc: true,
+        IgnoreInlineAttachments: true,
         ConfirmationDialogCardsOrder: [],
         FixedParameters: [],
       },
@@ -440,7 +450,8 @@ test_merge.parameters = {
         "ConvertToBccEnabled = true\n" +
         "ConvertToBccThreshold = 4\n" +
         "BlockDistributionLists = true\n" +
-        "EmphasizeUntrustedToCc = true",
+        "EmphasizeUntrustedToCc = true\n" +
+        "IgnoreInlineAttachments = true",
       trustedDomainsString: "trustedDomain_left",
       unsafeDomainsString: "unsafeDomain_left",
       unsafeFilesString: "unsafeFile_left",
@@ -473,6 +484,7 @@ test_merge.parameters = {
         ConvertToBccThreshold: 2,
         BlockDistributionLists: false,
         EmphasizeUntrustedToCc: false,
+        IgnoreInlineAttachments: false,
         ConfirmationDialogCardsOrder: ["UntrustedDomains", "TrustedDomains", "Subject", "Body", "Misc"],
         FixedParameters: ["CountSeconds"],
       },
@@ -512,6 +524,7 @@ test_merge.parameters = {
         "ConvertToBccThreshold = 2\n" +
         "BlockDistributionLists = false\n" +
         "EmphasizeUntrustedToCc = false\n" +
+        "IgnoreInlineAttachments = false\n" +
         "ConfirmationDialogCardsOrder = UntrustedDomains,TrustedDomains,Subject,Body,Misc\n" +
         "FixedParameters = CountSeconds",
       trustedDomainsString: "trustedDomain_right",
@@ -546,6 +559,7 @@ test_merge.parameters = {
         ConvertToBccThreshold: 2,
         BlockDistributionLists: false,
         EmphasizeUntrustedToCc: false,
+        IgnoreInlineAttachments: false,
         ConfirmationDialogCardsOrder: ["UntrustedDomains", "TrustedDomains", "Subject", "Body", "Misc"],
         FixedParameters: ["CountSeconds"],
       },
@@ -590,6 +604,7 @@ test_merge.parameters = {
         "ConvertToBccThreshold = 2\n" +
         "BlockDistributionLists = false\n" +
         "EmphasizeUntrustedToCc = false\n" +
+        "IgnoreInlineAttachments = false\n" +
         "ConfirmationDialogCardsOrder = UntrustedDomains,TrustedDomains,Subject,Body,Misc\n" +
         "FixedParameters = CountSeconds",
       trustedDomainsString: "trustedDomain_left\ntrustedDomain_right",
@@ -632,6 +647,7 @@ test_merge.parameters = {
         ConvertToBccThreshold: 3,
         BlockDistributionLists: true,
         EmphasizeUntrustedToCc: true,
+        IgnoreInlineAttachments: true,
         ConfirmationDialogCardsOrder: ["UntrustedDomains", "TrustedDomains", "Subject", "Body", "Misc"],
         FixedParameters: [
           "CountEnabled",
@@ -654,6 +670,7 @@ test_merge.parameters = {
           "ConvertToBccThreshold",
           "BlockDistributionLists",
           "EmphasizeUntrustedToCc",
+          "IgnoreInlineAttachments",
           "TrustedDomains",
           "UnsafeDomains",
           "UnsafeFiles",
@@ -697,6 +714,7 @@ test_merge.parameters = {
         "ConvertToBccThreshold = 3\n" +
         "BlockDistributionLists = true\n" +
         "EmphasizeUntrustedToCc = true\n" +
+        "IgnoreInlineAttachments = true\n" +
         "ConfirmationDialogCardsOrder = UntrustedDomains,TrustedDomains,Subject,Body,Misc\n" +
         "FixedParameters = " + 
             "CountEnabled," +
@@ -717,6 +735,7 @@ test_merge.parameters = {
             "ConvertToBccThreshold," +
             "BlockDistributionLists," +
             "EmphasizeUntrustedToCc," +
+            "IgnoreInlineAttachments," +
             "TrustedDomains," +
             "UnsafeDomains," +
             "UnsafeFiles," + 
@@ -754,6 +773,7 @@ test_merge.parameters = {
         ConvertToBccThreshold: 2,
         BlockDistributionLists: false,
         EmphasizeUntrustedToCc: false,
+        IgnoreInlineAttachments: false,
         ConfirmationDialogCardsOrder: ["UntrustedDomains", "TrustedDomains", "Subject", "Body", "Misc"],
         FixedParameters: ["CountSeconds"],
       },
@@ -788,6 +808,7 @@ test_merge.parameters = {
         "ConvertToBccThreshold = 2\n" +
         "BlockDistributionLists = false\n" +
         "EmphasizeUntrustedToCc = false\n" +
+        "IgnoreInlineAttachments = false\n" +
         "ConfirmationDialogCardsOrder = UntrustedDomains,TrustedDomains,Subject,Body,Misc\n" +
         "FixedParameters = CountSeconds",
       trustedDomainsString: "trustedDomain_right",
@@ -819,6 +840,7 @@ test_merge.parameters = {
         ConvertToBccThreshold: 3,
         BlockDistributionLists: true,
         EmphasizeUntrustedToCc: true,
+        IgnoreInlineAttachments: true,
         ConfirmationDialogCardsOrder: ["UntrustedDomains", "TrustedDomains", "Subject", "Body", "Misc"],
         FixedParameters: [
           "CountEnabled",
@@ -841,6 +863,7 @@ test_merge.parameters = {
           "ConvertToBccThreshold",
           "BlockDistributionLists",
           "EmphasizeUntrustedToCc",
+          "IgnoreInlineAttachments",
           "TrustedDomains",
           "UnsafeDomains",
           "UnsafeFiles",
@@ -884,6 +907,7 @@ test_merge.parameters = {
         "ConvertToBccThreshold = 3\n" +
         "BlockDistributionLists = true\n" +
         "EmphasizeUntrustedToCc = true\n" +
+        "IgnoreInlineAttachments = true\n" +
         "ConfirmationDialogCardsOrder = UntrustedDomains,TrustedDomains,Subject,Body,Misc\n" +
         "FixedParameters = " + 
           "CountEnabled," +
@@ -906,6 +930,7 @@ test_merge.parameters = {
           "ConvertToBccThreshold," +
           "BlockDistributionLists," +
           "EmphasizeUntrustedToCc," +
+          "IgnoreInlineAttachments," +
           "TrustedDomains," +
           "UnsafeDomains," +
           "UnsafeFiles," + 


### PR DESCRIPTION
Add an option to ignore inline image attachments

* Parameter name
  * `IgnoreInlineImageAttachments`
* Type
  * Boolean
* Default
  * `False`

If the `IgnoreInlineImageAttachments` is enabled, image type attachments attached inline is ignored from checking target.
The type of image is judged by its extension name.

## Test

* Open a FlexConfirmMail setting dialog
* Set IgnoreInlineImageAttachments ("文中に挿入された画像添付ファイルを確認対象から除外する") to false
* Close the setting dialog with the OK button
* Set Outlook's mail creation type to HTML
* Create a new mail
* Specify "test@example.com" as To
* Input "test" to subject
* Insert an image (e.g. "test.png") to body
  * <img width="454" height="340" alt="image" src="https://github.com/user-attachments/assets/8400f283-ec21-4649-8646-7cf86f0889b6" />
* Send the mail
  * [x] Confirm that the image (e.g. "test.png") is confirmed in the FlexConfirmMail confirmation dialog
  * <img width="506" height="180" alt="image" src="https://github.com/user-attachments/assets/e6b8276b-0032-4b74-9a1b-cb60d860b442" />
* Click the cancel button
* Open the FlexConfirmMail setting dialog
* Set IgnoreInlineImageAttachments ("文中に挿入された画像添付ファイルを確認対象から除外する") to true
* Close the setting dialog with the OK button
* Set Outlook's mail creation type to HTML
* Create a new mail
* Specify "test@example.com" as To
* Input "test" to subject
* Insert an image (e.g. "test.png") to body
  * <img width="454" height="340" alt="image" src="https://github.com/user-attachments/assets/8400f283-ec21-4649-8646-7cf86f0889b6" />
* Send the mail 
  * [x] Confirm that the image (e.g. "test.png") is not confirmed in the FlexConfirmMail confirmation dialog
  * <img width="999" height="354" alt="image" src="https://github.com/user-attachments/assets/7af9f982-6a63-4f7c-977e-33059a170667" />

* Click the cancel button

